### PR TITLE
Fix: register_soft_delete_features crashes when database doesn't exist

### DIFF
--- a/lib/command_post/resource.rb
+++ b/lib/command_post/resource.rb
@@ -640,6 +640,8 @@ module CommandPost
         action :restore, icon: "arrow-path" do |record|
           record.update(column => nil)
         end
+      rescue ActiveRecord::NoDatabaseError, ActiveRecord::StatementInvalid
+        nil
       end
 
       private


### PR DESCRIPTION
## Summary

- Rescue `ActiveRecord::NoDatabaseError` and `ActiveRecord::StatementInvalid` in `register_soft_delete_features` so eager loading doesn't crash when the database hasn't been created yet (common in CI pipelines)
- Add 3 tests covering the database-unavailable scenario

Closes #1

## Test plan

- [x] New tests verify `register_soft_delete_features` doesn't raise when `column_names` raises `NoDatabaseError` or `StatementInvalid`
- [x] New test verifies no scopes/actions are registered when DB is unavailable
- [x] All 1000 existing tests pass
- [x] Rubocop clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)