### PR TITLE
feat: Phase 2 - Associations and new field types

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,6 +216,7 @@ GEM
       erb
       psych (>= 4.0.0)
       tsort
+    redcarpet (3.6.1)
     regexp_parser (2.11.3)
     reline (0.6.3)
       io-console (~> 0.5)
@@ -315,6 +316,7 @@ PLATFORMS
 DEPENDENCIES
   command-post!
   factory_bot_rails (~> 6.4)
+  redcarpet (~> 3.6)
   rspec-rails (~> 7.0)
   rubocop (~> 1.60)
   rubocop-rails (~> 2.23)

--- a/app/helpers/command_post/application_helper.rb
+++ b/app/helpers/command_post/application_helper.rb
@@ -5,6 +5,7 @@ module CommandPost
   module ApplicationHelper
     include Heroicon::ApplicationHelper
     include CommandPost::ThemeHelper
+    include CommandPost::FieldDisplayHelper
 
     # Methods checked when displaying a record's label.
     # @return [Array<Symbol>]
@@ -29,6 +30,10 @@ module CommandPost
         display_files(record, field)
       when :rich_text
         display_rich_text(record, field)
+      when :tags
+        display_tags(record, field)
+      when :markdown
+        display_markdown(record, field)
       else
         record.public_send(field.name)
       end
@@ -74,92 +79,6 @@ module CommandPost
       else
         []
       end
-    end
-
-    private
-
-    def display_belongs_to(record, field)
-      associated = record.public_send(field.name)
-      return if associated.nil?
-
-      display_method = field.options[:display]
-      label = display_record_label(associated, display_method)
-
-      resource = CommandPost::ResourceRegistry.find(associated.class.model_name.plural)
-      if resource
-        link_to label, command_post.resource_path(resource.resource_name, associated),
-                class: cp_link
-      else
-        label
-      end
-    end
-
-    def display_badge(record, field)
-      value = record.public_send(field.name)
-      return if value.nil?
-
-      # First check field-level color overrides, then global badge_colors, then default to gray
-      colors = field.options[:colors] || {}
-      color = colors[value.to_sym] ||
-              CommandPost.configuration.badge_colors[value.to_s] ||
-              CommandPost.configuration.badge_colors[value] ||
-              :gray
-      color_classes = badge_color_classes(color)
-
-      content_tag(:span, value.to_s.humanize,
-                  class: "inline-flex px-2 py-1 text-xs font-semibold rounded-full #{color_classes}")
-    end
-
-    def badge_color_classes(color)
-      CommandPost::Configuration::BADGE_COLOR_CLASSES[color.to_sym] ||
-        CommandPost::Configuration::BADGE_COLOR_CLASSES[:gray]
-    end
-
-    def display_password
-      content_tag(:span, "\u2022" * 8, class: "text-gray-400 tracking-wider")
-    end
-
-    def display_file(record, field)
-      return unless record.respond_to?(field.name)
-
-      attachment = record.public_send(field.name)
-      return unless attachment.attached?
-
-      if attachment.image?
-        image_tag main_app.url_for(attachment), class: "h-16 w-16 object-cover rounded"
-      else
-        content_tag(:span, class: "inline-flex items-center gap-1.5") do
-          heroicon("paper-clip", variant: :mini, options: { class: "h-4 w-4 #{cp_muted_text}" }) +
-            content_tag(:span, attachment.filename.to_s, class: cp_link)
-        end
-      end
-    end
-
-    def display_files(record, field)
-      return unless record.respond_to?(field.name)
-
-      attachments = record.public_send(field.name)
-      return unless attachments.attached?
-
-      content_tag(:div, class: "flex flex-wrap gap-2") do
-        safe_join(
-          attachments.map do |attachment|
-            if attachment.image?
-              image_tag main_app.url_for(attachment), class: "h-12 w-12 object-cover rounded"
-            else
-              content_tag(:span, attachment.filename.to_s,
-                          class: "inline-flex items-center px-2 py-1 text-xs rounded bg-gray-100 text-gray-700")
-            end
-          end
-        )
-      end
-    end
-
-    def display_rich_text(record, field)
-      content = record.public_send(field.name)
-      return if content.blank?
-
-      content_tag(:div, content.to_s.html_safe, class: "prose prose-sm max-w-none") # rubocop:disable Rails/OutputSafety
     end
   end
 end

--- a/app/helpers/command_post/field_display_helper.rb
+++ b/app/helpers/command_post/field_display_helper.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module CommandPost
+  # Private helper methods for rendering specific field types.
+  # Extracted from ApplicationHelper for organization.
+  module FieldDisplayHelper
+    private
+
+    def display_belongs_to(record, field)
+      associated = record.public_send(field.name)
+      return if associated.nil?
+
+      display_method = field.options[:display]
+      label = display_record_label(associated, display_method)
+
+      resource = CommandPost::ResourceRegistry.find(associated.class.model_name.plural)
+      if resource
+        link_to label, command_post.resource_path(resource.resource_name, associated),
+                class: cp_link
+      else
+        label
+      end
+    end
+
+    def display_badge(record, field)
+      value = record.public_send(field.name)
+      return if value.nil?
+
+      colors = field.options[:colors] || {}
+      color = colors[value.to_sym] ||
+              CommandPost.configuration.badge_colors[value.to_s] ||
+              CommandPost.configuration.badge_colors[value] ||
+              :gray
+      color_classes = badge_color_classes(color)
+
+      content_tag(:span, value.to_s.humanize,
+                  class: "inline-flex px-2 py-1 text-xs font-semibold rounded-full #{color_classes}")
+    end
+
+    def badge_color_classes(color)
+      CommandPost::Configuration::BADGE_COLOR_CLASSES[color.to_sym] ||
+        CommandPost::Configuration::BADGE_COLOR_CLASSES[:gray]
+    end
+
+    def display_password
+      content_tag(:span, "\u2022" * 8, class: "text-gray-400 tracking-wider")
+    end
+
+    def display_file(record, field)
+      return unless record.respond_to?(field.name)
+
+      attachment = record.public_send(field.name)
+      return unless attachment.attached?
+
+      if attachment.image?
+        image_tag main_app.url_for(attachment), class: "h-16 w-16 object-cover rounded"
+      else
+        content_tag(:span, class: "inline-flex items-center gap-1.5") do
+          heroicon("paper-clip", variant: :mini, options: { class: "h-4 w-4 #{cp_muted_text}" }) +
+            content_tag(:span, attachment.filename.to_s, class: cp_link)
+        end
+      end
+    end
+
+    def display_files(record, field)
+      return unless record.respond_to?(field.name)
+
+      attachments = record.public_send(field.name)
+      return unless attachments.attached?
+
+      content_tag(:div, class: "flex flex-wrap gap-2") do
+        safe_join(
+          attachments.map do |attachment|
+            if attachment.image?
+              image_tag main_app.url_for(attachment), class: "h-12 w-12 object-cover rounded"
+            else
+              content_tag(:span, attachment.filename.to_s,
+                          class: "inline-flex items-center px-2 py-1 text-xs rounded bg-gray-100 text-gray-700")
+            end
+          end
+        )
+      end
+    end
+
+    def display_rich_text(record, field)
+      content = record.public_send(field.name)
+      return if content.blank?
+
+      content_tag(:div, content.to_s.html_safe, class: "prose prose-sm max-w-none") # rubocop:disable Rails/OutputSafety
+    end
+
+    def display_markdown(record, field)
+      content = record.public_send(field.name)
+      return if content.blank?
+
+      begin
+        require "redcarpet"
+        renderer = Redcarpet::Render::HTML.new(hard_wrap: true, filter_html: true)
+        markdown = Redcarpet::Markdown.new(renderer, autolink: true, tables: true, fenced_code_blocks: true)
+        content_tag(:div, markdown.render(content).html_safe, class: "prose prose-sm max-w-none") # rubocop:disable Rails/OutputSafety
+      rescue LoadError
+        content_tag(:pre, content, class: "text-sm whitespace-pre-wrap #{cp_body_text}")
+      end
+    end
+
+    def display_tags(record, field)
+      value = record.public_send(field.name)
+      return if value.blank?
+
+      tags = value.is_a?(Array) ? value : value.to_s.split(",").map(&:strip)
+      return if tags.empty?
+
+      content_tag(:div, class: "flex flex-wrap gap-1") do
+        safe_join(
+          tags.map do |tag|
+            content_tag(:span, tag,
+                        class: "inline-flex px-2 py-0.5 text-xs font-medium rounded-full bg-indigo-50 text-indigo-700")
+          end
+        )
+      end
+    end
+  end
+end

--- a/app/views/command_post/resources/_form.html.haml
+++ b/app/views/command_post/resources/_form.html.haml
@@ -5,7 +5,7 @@
     - @fields.each do |field|
       - next unless field.visible?(command_post_current_user)
       - next if field.readonly?(command_post_current_user)
-      - span_full = field.type.in?(%i[textarea json file files rich_text])
+      - span_full = field.type.in?(%i[textarea json file files rich_text tags markdown])
       - has_error = @record.errors[field.name].any?
       %div{ class: span_full ? "md:col-span-2 2xl:col-span-3" : nil }
         = f.label field.name, field.name.to_s.humanize,
@@ -72,8 +72,74 @@
                       %span.text-xs{ class: cp_body_text }= attachment.filename
           = f.file_field field.name, multiple: true,
             class: [cp_file_input_class, (error_input_class if has_error)].compact.join(" ")
+        - when :markdown
+          = f.text_area field.name, rows: 8, placeholder: "Write markdown here...",
+            class: [cp_textarea_class, "font-mono text-sm", (error_input_class if has_error)].compact.join(" ")
         - when :rich_text
           = f.rich_text_area field.name, class: "trix-content"
+        - when :tags
+          - current_tags = @record.public_send(field.name)
+          - tag_values = current_tags.is_a?(Array) ? current_tags : current_tags.to_s.split(",").map(&:strip).reject(&:blank?)
+          - container_id = "tags-container-#{field.name}"
+          %div{ id: container_id, data: { tags_field: true } }
+            = f.hidden_field field.name, value: tag_values.join(","), id: "tags-hidden-#{field.name}"
+            .flex.flex-wrap.gap-2.mb-2{ data: { tags_list: true } }
+              - tag_values.each do |tag_value|
+                %span.inline-flex.items-center.gap-1.px-2.py-1.text-sm.rounded-full.bg-indigo-50.text-indigo-700{ data: { tag: true } }
+                  = tag_value
+                  %button.ml-1.text-indigo-400.hover:text-indigo-600{ type: "button", data: { remove_tag: true } } &times;
+            .flex.items-center.gap-2
+              %input.flex-1{ type: "text", placeholder: "Type and press Enter to add...", data: { tag_input: true },
+                class: [cp_input_class, (error_input_class if has_error)].compact.join(" ") }
+          :javascript
+            (function() {
+              const container = document.getElementById("#{container_id}");
+              const hidden = container.querySelector("[data-tags-list] ~ .flex input[data-tag-input]").closest("[data-tags-field]").querySelector("input[type=hidden]");
+              const list = container.querySelector("[data-tags-list]");
+              const input = container.querySelector("[data-tag-input]");
+
+              function updateHidden() {
+                const tags = Array.from(list.querySelectorAll("[data-tag]")).map(el => el.textContent.replace("×", "").trim());
+                hidden.value = tags.join(",");
+              }
+
+              function addTag(value) {
+                const trimmed = value.trim();
+                if (!trimmed) return;
+                const existing = Array.from(list.querySelectorAll("[data-tag]")).map(el => el.textContent.replace("×", "").trim());
+                if (existing.includes(trimmed)) return;
+
+                const span = document.createElement("span");
+                span.className = "inline-flex items-center gap-1 px-2 py-1 text-sm rounded-full bg-indigo-50 text-indigo-700";
+                span.dataset.tag = true;
+                span.textContent = trimmed;
+                const btn = document.createElement("button");
+                btn.type = "button";
+                btn.className = "ml-1 text-indigo-400 hover:text-indigo-600";
+                btn.dataset.removeTag = true;
+                btn.textContent = "×";
+                btn.addEventListener("click", function() { span.remove(); updateHidden(); });
+                span.appendChild(btn);
+                list.appendChild(span);
+                updateHidden();
+              }
+
+              input.addEventListener("keydown", function(e) {
+                if (e.key === "Enter" || e.key === ",") {
+                  e.preventDefault();
+                  addTag(input.value);
+                  input.value = "";
+                }
+              });
+
+              input.addEventListener("blur", function() {
+                if (input.value.trim()) { addTag(input.value); input.value = ""; }
+              });
+
+              list.querySelectorAll("[data-remove-tag]").forEach(function(btn) {
+                btn.addEventListener("click", function() { btn.closest("[data-tag]").remove(); updateHidden(); });
+              });
+            })();
         - else
           = f.text_field field.name, placeholder: field.name.to_s.humanize,
             class: [cp_input_class, (error_input_class if has_error)].compact.join(" ")
@@ -82,6 +148,17 @@
           .flex.items-center{ class: "gap-1.5 mt-1.5" }
             = heroicon "exclamation-circle", variant: :mini, options: { class: "h-4 w-4 text-red-500 shrink-0" }
             %p.text-sm.text-red-600= @record.errors[field.name].join(", ")
+
+  - @resource_class.habtm_associations.each do |assoc|
+    .md:col-span-2.2xl:col-span-3.mt-4
+      %label.block.text-sm.font-medium.mb-2{ class: cp_label_text }= assoc[:name].to_s.humanize
+      - all_options = assoc[:reflection].klass.all
+      - selected_ids = @record.public_send(assoc[:name]).pluck(:id)
+      .flex.flex-wrap.gap-3
+        - all_options.each do |option|
+          %label.inline-flex.items-center.gap-2.cursor-pointer
+            = check_box_tag "record[#{assoc[:name].to_s.singularize}_ids][]", option.id, selected_ids.include?(option.id), class: cp_checkbox_class
+            %span.text-sm{ class: cp_body_text }= display_record_label(option, assoc[:display])
 
   .flex.items-center.gap-3.mt-8.pt-6.border-t{ class: t.card_border }
     = f.submit class: cp_btn_primary_lg

--- a/app/views/command_post/resources/show.html.haml
+++ b/app/views/command_post/resources/show.html.haml
@@ -20,6 +20,41 @@
           %dt.text-sm.font-medium{ class: "w-1/3 #{cp_muted_text}" }= field.name.to_s.humanize
           %dd.text-sm{ class: "w-2/3 #{cp_body_text}" }= display_field_value(@record, field)
 
+  - @resource_class.has_one_associations.each do |assoc|
+    - related_record = @record.public_send(assoc[:name])
+    - next unless related_record
+    .mt-6.overflow-hidden{ class: cp_card }
+      .px-6.py-4.border-b.flex.items-center.justify-between{ class: t.card_border }
+        %h2.text-lg.font-semibold= assoc[:name].to_s.humanize
+        = link_to "View",
+          resource_path(assoc[:resource].resource_name, related_record),
+          class: "text-sm #{cp_link}"
+      %dl{ class: "#{cp_table_border} divide-y" }
+        - assoc[:resource].resolved_fields.first(6).each do |field|
+          - next if field.name == :id
+          - next unless field.visible?(command_post_current_user)
+          .px-6.py-3.flex.items-center
+            %dt.text-sm.font-medium{ class: "w-1/3 #{cp_muted_text}" }= field.name.to_s.humanize
+            %dd.text-sm{ class: "w-2/3 #{cp_body_text}" }= display_field_value(related_record, field)
+
+  - @resource_class.habtm_associations.each do |assoc|
+    - related_records = @record.public_send(assoc[:name])
+    - next if related_records.empty?
+    .mt-6.overflow-hidden{ class: cp_card }
+      .px-6.py-4.border-b{ class: t.card_border }
+        %h2.text-lg.font-semibold= assoc[:name].to_s.humanize
+      .px-6.py-4
+        .flex.flex-wrap.gap-2
+          - related_records.each do |related|
+            - display = assoc[:display]
+            - if assoc[:resource]
+              = link_to display_record_label(related, display),
+                resource_path(assoc[:resource].resource_name, related),
+                class: "inline-flex px-3 py-1 text-sm font-medium rounded-full bg-indigo-50 text-indigo-700 hover:bg-indigo-100 transition-colors"
+            - else
+              %span.inline-flex.px-3.py-1.text-sm.font-medium.rounded-full.bg-gray-100.text-gray-700
+                = display_record_label(related, display)
+
   - @resource_class.has_many_associations.each do |assoc|
     - related_records = @record.public_send(assoc[:name]).limit(20)
     - next if related_records.empty?

--- a/command_post.gemspec
+++ b/command_post.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "view_component", ">= 3.0"
 
   spec.add_development_dependency "factory_bot_rails", "~> 6.4"
+  spec.add_development_dependency "redcarpet", "~> 3.6"
   spec.add_development_dependency "rspec-rails", "~> 7.0"
   spec.add_development_dependency "rubocop", "~> 1.60"
   spec.add_development_dependency "rubocop-rails", "~> 2.23"

--- a/spec/dummy/app/command_post/post_resource.rb
+++ b/spec/dummy/app/command_post/post_resource.rb
@@ -1,4 +1,9 @@
 class PostResource < CommandPost::Resource
+  has_and_belongs_to_many :tags
+
+  field :category_tags, type: :tags
+  field :body_markdown, type: :markdown
+
   searchable :title
   menu icon: "document-text", group: "Content"
 end

--- a/spec/dummy/app/command_post/profile_resource.rb
+++ b/spec/dummy/app/command_post/profile_resource.rb
@@ -1,0 +1,7 @@
+class ProfileResource < CommandPost::Resource
+  belongs_to :user, display: :name
+
+  searchable :bio, :website
+
+  menu icon: "user-circle", group: "Users"
+end

--- a/spec/dummy/app/command_post/tag_resource.rb
+++ b/spec/dummy/app/command_post/tag_resource.rb
@@ -1,0 +1,5 @@
+class TagResource < CommandPost::Resource
+  searchable :name
+
+  menu icon: "tag", group: "Content"
+end

--- a/spec/dummy/app/command_post/user_resource.rb
+++ b/spec/dummy/app/command_post/user_resource.rb
@@ -4,6 +4,7 @@ class UserResource < CommandPost::Resource
   filter :role, type: :select
 
   has_many :licenses
+  has_one :profile
 
   menu priority: 0, icon: "users", group: "Users"
 end

--- a/spec/dummy/app/models/post.rb
+++ b/spec/dummy/app/models/post.rb
@@ -1,3 +1,5 @@
 class Post < ApplicationRecord
+  has_and_belongs_to_many :tags # rubocop:disable Rails/HasAndBelongsToMany
+
   validates :title, presence: true
 end

--- a/spec/dummy/app/models/profile.rb
+++ b/spec/dummy/app/models/profile.rb
@@ -1,0 +1,5 @@
+class Profile < ApplicationRecord
+  belongs_to :user
+
+  validates :user_id, uniqueness: true
+end

--- a/spec/dummy/app/models/tag.rb
+++ b/spec/dummy/app/models/tag.rb
@@ -1,0 +1,5 @@
+class Tag < ApplicationRecord
+  has_and_belongs_to_many :posts # rubocop:disable Rails/HasAndBelongsToMany
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_many :licenses
+  has_one :profile
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -24,7 +24,31 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_01_000005) do
   create_table :posts, force: :cascade do |t|
     t.string :title, null: false
     t.boolean :published, default: false
+    t.string :category_tags
+    t.text :body_markdown
     t.timestamps
+  end
+
+  create_table :profiles, force: :cascade do |t|
+    t.references :user, foreign_key: true, null: false, index: { unique: true }
+    t.text :bio
+    t.string :website
+    t.string :avatar_url
+    t.timestamps
+  end
+
+  create_table :tags, force: :cascade do |t|
+    t.string :name, null: false
+    t.timestamps
+
+    t.index :name, unique: true
+  end
+
+  create_table :posts_tags, id: false, force: :cascade do |t|
+    t.references :post, foreign_key: true, null: false
+    t.references :tag, foreign_key: true, null: false
+
+    t.index [:post_id, :tag_id], unique: true
   end
 
   create_table :documents, force: :cascade do |t|

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :post do
+    sequence(:title) { |n| "Post #{n}" }
+    published { false }
+  end
+end

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :profile do
+    user
+    bio { "A short bio about this user." }
+    website { "https://example.com" }
+    avatar_url { "https://example.com/avatar.png" }
+  end
+end

--- a/spec/factories/tags.rb
+++ b/spec/factories/tags.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :tag do
+    sequence(:name) { |n| "tag-#{n}" }
+  end
+end

--- a/spec/lib/command_post/resource_spec.rb
+++ b/spec/lib/command_post/resource_spec.rb
@@ -178,6 +178,11 @@ RSpec.describe CommandPost::Resource do
       expect(assoc[:kind]).to eq(:has_many)
     end
 
+    it "stores has_one declarations" do
+      assoc = TestUserResource.defined_associations[:profile]
+      expect(assoc[:kind]).to eq(:has_one)
+    end
+
     it "resolves has_many associations with resource and reflection" do
       CommandPost::ResourceRegistry.reset!
       CommandPost::ResourceRegistry.register(TestUserResource)
@@ -187,6 +192,47 @@ RSpec.describe CommandPost::Resource do
       licenses_assoc = associations.find { |a| a[:name] == :licenses }
       expect(licenses_assoc).to be_present
       expect(licenses_assoc[:resource]).to eq(TestLicenseResource)
+    end
+
+    it "resolves has_one associations with resource and reflection" do
+      CommandPost::ResourceRegistry.reset!
+      CommandPost::ResourceRegistry.register(TestUserResource)
+      CommandPost::ResourceRegistry.register(ProfileResource)
+
+      associations = TestUserResource.has_one_associations
+      profile_assoc = associations.find { |a| a[:name] == :profile }
+      expect(profile_assoc).to be_present
+      expect(profile_assoc[:resource]).to eq(ProfileResource)
+    end
+
+    it "returns empty for has_one when no associations defined" do
+      CommandPost::ResourceRegistry.reset!
+      CommandPost::ResourceRegistry.register(TestLicenseResource)
+
+      expect(TestLicenseResource.has_one_associations).to eq([])
+    end
+
+    it "stores has_and_belongs_to_many declarations" do
+      assoc = PostResource.defined_associations[:tags]
+      expect(assoc[:kind]).to eq(:has_and_belongs_to_many)
+    end
+
+    it "resolves habtm associations with reflection" do
+      CommandPost::ResourceRegistry.reset!
+      CommandPost::ResourceRegistry.register(PostResource)
+      CommandPost::ResourceRegistry.register(TagResource)
+
+      associations = PostResource.habtm_associations
+      tags_assoc = associations.find { |a| a[:name] == :tags }
+      expect(tags_assoc).to be_present
+      expect(tags_assoc[:resource]).to eq(TagResource)
+    end
+
+    it "returns empty for habtm when no associations defined" do
+      CommandPost::ResourceRegistry.reset!
+      CommandPost::ResourceRegistry.register(TestUserResource)
+
+      expect(TestUserResource.habtm_associations).to eq([])
     end
 
     it "infers belongs_to fields from model" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -19,6 +19,8 @@ require_relative "dummy/app/command_post/user_resource"
 require_relative "dummy/app/command_post/license_resource"
 require_relative "dummy/app/command_post/post_resource"
 require_relative "dummy/app/command_post/document_resource"
+require_relative "dummy/app/command_post/profile_resource"
+require_relative "dummy/app/command_post/tag_resource"
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = true

--- a/spec/requests/command_post/soft_delete_spec.rb
+++ b/spec/requests/command_post/soft_delete_spec.rb
@@ -2,37 +2,39 @@ require "rails_helper"
 
 RSpec.describe "CommandPost Soft Delete Integration", type: :request do
   # Create a temporary table with deleted_at column for testing
+  # Uses a unique table name to avoid collisions with the real posts table
   before(:all) do
-    ActiveRecord::Base.connection.create_table :posts, force: true do |t|
+    ActiveRecord::Base.connection.create_table :soft_delete_posts, force: true do |t|
       t.string :title
       t.text :body
       t.datetime :deleted_at
       t.timestamps
     end
 
-    # Define the Post model dynamically
-    Object.const_set(:Post, Class.new(ApplicationRecord) do
+    # Define the SoftDeletePost model dynamically
+    Object.const_set(:SoftDeletePost, Class.new(ApplicationRecord) do
+      self.table_name = "soft_delete_posts"
       # Simulate paranoia/discard default scope
       default_scope { where(deleted_at: nil) }
     end)
   end
 
   after(:all) do
-    ActiveRecord::Base.connection.drop_table :posts, if_exists: true
-    Object.send(:remove_const, :Post) if defined?(Post)
+    ActiveRecord::Base.connection.drop_table :soft_delete_posts, if_exists: true
+    Object.send(:remove_const, :SoftDeletePost) if defined?(SoftDeletePost)
   end
 
-  # Create PostResource for testing
+  # Create SoftDeletePostResource for testing
   let(:post_resource) do
     Class.new(CommandPost::Resource) do
-      self.model_class_override = Post
+      self.model_class_override = SoftDeletePost
 
       def self.name
-        "PostResource"
+        "SoftDeletePostResource"
       end
 
       def self.resource_name
-        "posts"
+        "soft_delete_posts"
       end
     end
   end
@@ -44,25 +46,25 @@ RSpec.describe "CommandPost Soft Delete Integration", type: :request do
   end
 
   describe "GET /:resource_name with soft delete scopes" do
-    let!(:active_post) { Post.create!(title: "Active Post", body: "Content") }
-    let!(:deleted_post) { Post.unscoped.create!(title: "Deleted Post", body: "Content", deleted_at: Time.current) }
+    let!(:active_post) { SoftDeletePost.create!(title: "Active Post", body: "Content") }
+    let!(:deleted_post) { SoftDeletePost.unscoped.create!(title: "Deleted Post", body: "Content", deleted_at: Time.current) }
 
     it "shows only non-deleted records by default" do
-      get command_post.resources_path("posts"), as: :html
+      get command_post.resources_path("soft_delete_posts"), as: :html
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Active Post")
       expect(response.body).not_to include("Deleted Post")
     end
 
     it "shows all records with with_deleted scope" do
-      get command_post.resources_path("posts"), params: { scope: "with_deleted" }, as: :html
+      get command_post.resources_path("soft_delete_posts"), params: { scope: "with_deleted" }, as: :html
       expect(response).to have_http_status(:ok)
       expect(response.body).to include("Active Post")
       expect(response.body).to include("Deleted Post")
     end
 
     it "shows only deleted records with only_deleted scope" do
-      get command_post.resources_path("posts"), params: { scope: "only_deleted" }, as: :html
+      get command_post.resources_path("soft_delete_posts"), params: { scope: "only_deleted" }, as: :html
       expect(response).to have_http_status(:ok)
       expect(response.body).not_to include("Active Post")
       expect(response.body).to include("Deleted Post")
@@ -70,21 +72,19 @@ RSpec.describe "CommandPost Soft Delete Integration", type: :request do
   end
 
   describe "POST /:resource_name/:id/actions/restore" do
-    let!(:deleted_post) { Post.unscoped.create!(title: "Deleted Post", body: "Content", deleted_at: Time.current) }
+    let!(:deleted_post) { SoftDeletePost.unscoped.create!(title: "Deleted Post", body: "Content", deleted_at: Time.current) }
 
     it "restores a soft deleted record" do
       expect(deleted_post.deleted_at).to be_present
 
-      # The restore action needs to find the record with unscoped query
-      # Since the controller uses model.find, we need to use unscoped
-      post command_post.resource_action_path("posts", deleted_post.id, "restore"), as: :html
+      post command_post.resource_action_path("soft_delete_posts", deleted_post.id, "restore"), as: :html
 
       expect(deleted_post.reload.deleted_at).to be_nil
     end
 
     it "redirects to the show page after restore" do
-      post command_post.resource_action_path("posts", deleted_post.id, "restore"), as: :html
-      expect(response).to redirect_to(command_post.resource_path("posts", deleted_post))
+      post command_post.resource_action_path("soft_delete_posts", deleted_post.id, "restore"), as: :html
+      expect(response).to redirect_to(command_post.resource_path("soft_delete_posts", deleted_post))
     end
   end
 end


### PR DESCRIPTION
## Summary

- **has_one associations**: Displays inline on show pages with field cards and "View" links
- **has_and_belongs_to_many associations**: Checkbox multi-select on forms, badge links on show pages
- **Tags field type**: Interactive tag input (add with Enter/comma, click to remove), stored as comma-separated string, displayed as indigo badges
- **Markdown field type**: Renders with Redcarpet (optional gem) with `rescue LoadError` fallback to `<pre>` tag; monospace textarea on forms
- **Extracted FieldDisplayHelper**: Refactored private display methods from ApplicationHelper for Metrics/ModuleLength compliance

## Test plan

- [x] 1060 examples, 0 failures
- [x] 97.09% line coverage (above 95% threshold)
- [x] RuboCop clean on all gem files
- [x] has_one: show with/without associated record
- [x] HABTM: show badges, form checkboxes, create/update/remove associations
- [x] Tags: display badges, form input, create/update/clear, nil/empty handling
- [x] Markdown: render HTML, fenced code blocks, nil/empty handling, edit pre-fill

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)