### PR TITLE
feat: Phase 3 - Display field types and smart formatting

### DIFF
--- a/app/components/command_post/resources/data_table_component.html.haml
+++ b/app/components/command_post/resources/data_table_component.html.haml
@@ -26,7 +26,7 @@
         %tr{ class: theme.table_row_hover }
           - visible_fields.each do |field|
             %td.px-6.py-4.whitespace-nowrap.text-sm{ class: theme.body_text }
-              = helpers.display_field_value(record, field)
+              = helpers.display_index_field_value(record, field)
           %td.px-6.py-4.whitespace-nowrap.text-right.text-sm
             = link_to "View", helpers.command_post.resource_path(resource_class.resource_name, record),
               class: theme.link, data: { turbo_frame: "_top" }

--- a/app/helpers/command_post/field_display_helper.rb
+++ b/app/helpers/command_post/field_display_helper.rb
@@ -3,7 +3,7 @@
 module CommandPost
   # Private helper methods for rendering specific field types.
   # Extracted from ApplicationHelper for organization.
-  module FieldDisplayHelper
+  module FieldDisplayHelper # rubocop:disable Metrics/ModuleLength
     private
 
     def display_belongs_to(record, field)
@@ -118,6 +118,70 @@ module CommandPost
           end
         )
       end
+    end
+
+    def display_url(record, field)
+      value = record.public_send(field.name)
+      return if value.blank?
+
+      content_tag(:span, class: "inline-flex items-center gap-1") do
+        link_to(value, value, target: "_blank", rel: "noopener noreferrer", class: cp_link) +
+          heroicon("arrow-top-right-on-square", variant: :mini, options: { class: "h-3.5 w-3.5 #{cp_muted_text}" })
+      end
+    end
+
+    def display_email(record, field)
+      value = record.public_send(field.name)
+      return if value.blank?
+
+      link_to(value, "mailto:#{value}", class: cp_link)
+    end
+
+    def display_color(record, field)
+      value = record.public_send(field.name)
+      return if value.blank?
+
+      content_tag(:span, class: "inline-flex items-center gap-2") do
+        content_tag(:span, "", class: "inline-block h-5 w-5 rounded border border-gray-300",
+                               style: "background-color: #{ERB::Util.html_escape(value)}") +
+          content_tag(:code, value, class: "text-xs #{cp_muted_text}")
+      end
+    end
+
+    def display_currency(record, field)
+      value = record.public_send(field.name)
+      return if value.nil?
+
+      symbol = field.options[:symbol] || "$"
+      precision = field.options[:precision] || 2
+      formatted = number_with_delimiter(format("%.#{precision}f", value.to_f))
+      content_tag(:span, "#{symbol}#{formatted}", class: "tabular-nums")
+    end
+
+    def display_boolean(record, field)
+      value = record.public_send(field.name)
+
+      if value
+        heroicon("check-circle", variant: :mini, options: { class: "h-5 w-5 text-green-500" })
+      else
+        heroicon("x-circle", variant: :mini, options: { class: "h-5 w-5 text-red-400" })
+      end
+    end
+
+    def display_date(record, field)
+      value = record.public_send(field.name)
+      return if value.nil?
+
+      fmt = field.options[:format] || "%b %d, %Y"
+      value.strftime(fmt)
+    end
+
+    def display_datetime(record, field)
+      value = record.public_send(field.name)
+      return if value.nil?
+
+      fmt = field.options[:format] || "%b %d, %Y at %l:%M %p"
+      value.strftime(fmt).squish
     end
   end
 end

--- a/app/views/command_post/resources/_form.html.haml
+++ b/app/views/command_post/resources/_form.html.haml
@@ -42,6 +42,24 @@
         - when :password
           = f.password_field field.name, placeholder: field.name.to_s.humanize, autocomplete: "new-password",
             class: [cp_input_class, (error_input_class if has_error)].compact.join(" ")
+        - when :url
+          = f.url_field field.name, placeholder: "https://",
+            class: [cp_input_class, (error_input_class if has_error)].compact.join(" ")
+        - when :email
+          = f.email_field field.name, placeholder: "user@example.com",
+            class: [cp_input_class, (error_input_class if has_error)].compact.join(" ")
+        - when :color
+          .flex.items-center.gap-3
+            = f.color_field field.name, class: "h-10 w-14 rounded border border-gray-300 cursor-pointer p-0.5"
+            = f.text_field field.name, placeholder: "#000000",
+              class: [cp_input_class, "flex-1 font-mono text-sm", (error_input_class if has_error)].compact.join(" "),
+              data: { color_text: true }
+        - when :currency
+          .relative
+            %span.pointer-events-none.absolute.inset-y-0.left-0.flex.items-center.pl-3.text-gray-500.text-sm
+              = field.options[:symbol] || "$"
+            = f.number_field field.name, step: "0.01", placeholder: "0.00",
+              class: [cp_input_class, "pl-7", (error_input_class if has_error)].compact.join(" ")
         - when :file
           - attachment = @record.public_send(field.name) if @record.respond_to?(field.name)
           - if attachment&.attached?

--- a/app/views/command_post/resources/index.html.haml
+++ b/app/views/command_post/resources/index.html.haml
@@ -97,7 +97,7 @@
             - @fields.each do |field|
               - next unless field.visible?(command_post_current_user)
               %td.px-6.py-4.whitespace-nowrap.text-sm{ class: cp_body_text }
-                = display_field_value(record, field)
+                = display_index_field_value(record, field)
             %td.px-6.py-4.whitespace-nowrap.text-right.text-sm
               = link_to "View", resource_path(@resource_class.resource_name, record),
                 class: cp_link, data: { turbo_frame: "_top" }

--- a/spec/dummy/app/command_post/profile_resource.rb
+++ b/spec/dummy/app/command_post/profile_resource.rb
@@ -1,6 +1,11 @@
 class ProfileResource < CommandPost::Resource
   belongs_to :user, display: :name
 
+  field :website, type: :url
+  field :avatar_url, type: :url
+  field :color_hex, type: :color
+  field :hourly_rate, type: :currency, options: { symbol: "$", precision: 2 }
+
   searchable :bio, :website
 
   menu icon: "user-circle", group: "Users"

--- a/spec/dummy/app/command_post/user_resource.rb
+++ b/spec/dummy/app/command_post/user_resource.rb
@@ -1,4 +1,6 @@
 class UserResource < CommandPost::Resource
+  field :email, type: :email
+
   searchable :name, :email
 
   filter :role, type: :select

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -34,6 +34,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_01_000005) do
     t.text :bio
     t.string :website
     t.string :avatar_url
+    t.string :color_hex
+    t.decimal :hourly_rate, precision: 10, scale: 2
     t.timestamps
   end
 

--- a/spec/factories/profiles.rb
+++ b/spec/factories/profiles.rb
@@ -4,5 +4,7 @@ FactoryBot.define do
     bio { "A short bio about this user." }
     website { "https://example.com" }
     avatar_url { "https://example.com/avatar.png" }
+    color_hex { "#3b82f6" }
+    hourly_rate { 75.50 }
   end
 end

--- a/spec/lib/command_post/field_inferrer_spec.rb
+++ b/spec/lib/command_post/field_inferrer_spec.rb
@@ -8,9 +8,14 @@ RSpec.describe CommandPost::FieldInferrer do
       expect(fields).to all(be_a(CommandPost::Field))
     end
 
-    it "infers string columns as text type" do
+    it "infers plain string columns as text type" do
+      name_field = fields.find { |f| f.name == :name }
+      expect(name_field.type).to eq(:text)
+    end
+
+    it "auto-detects email columns as email type" do
       email_field = fields.find { |f| f.name == :email }
-      expect(email_field.type).to eq(:text)
+      expect(email_field.type).to eq(:email)
     end
 
     it "infers boolean columns as boolean type" do
@@ -63,6 +68,20 @@ RSpec.describe CommandPost::FieldInferrer do
         content_field = fields.find { |f| f.name == :content }
         expect(content_field).to be_present
         expect(content_field.type).to eq(:rich_text)
+      end
+    end
+
+    context "with URL and email column name patterns" do
+      subject(:fields) { described_class.call(Profile) }
+
+      it "auto-detects *_url columns as url type" do
+        avatar_field = fields.find { |f| f.name == :avatar_url }
+        expect(avatar_field.type).to eq(:url)
+      end
+
+      it "auto-detects website column as url type" do
+        website_field = fields.find { |f| f.name == :website }
+        expect(website_field.type).to eq(:url)
       end
     end
 

--- a/spec/requests/command_post/display_formatting_spec.rb
+++ b/spec/requests/command_post/display_formatting_spec.rb
@@ -1,0 +1,276 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Display Formatting", type: :request do
+  before do
+    CommandPost::ResourceRegistry.register(ProfileResource)
+  end
+
+  describe "URL field type" do
+    describe "GET /:resource_name/:id (show)" do
+      it "renders URL as clickable link" do
+        profile = create(:profile, website: "https://example.com")
+        get command_post.resource_path("profiles", profile), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('href="https://example.com"')
+        expect(response.body).to include('target="_blank"')
+        expect(response.body).to include("noopener noreferrer")
+      end
+
+      it "handles blank URL gracefully" do
+        profile = create(:profile, website: "")
+        get command_post.resource_path("profiles", profile), as: :html
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "handles nil URL gracefully" do
+        profile = create(:profile, website: nil)
+        get command_post.resource_path("profiles", profile), as: :html
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /:resource_name/new" do
+      it "renders form with URL input" do
+        get command_post.new_resource_path("profiles"), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('type="url"')
+        expect(response.body).to include("https://")
+      end
+    end
+
+    describe "POST /:resource_name (create)" do
+      it "creates record with URL field" do
+        user = create(:user)
+        post command_post.resources_path("profiles"),
+             params: { record: { user_id: user.id, website: "https://newsite.com" } },
+             as: :html
+
+        expect(Profile.last.website).to eq("https://newsite.com")
+      end
+    end
+  end
+
+  describe "email field type" do
+    describe "GET /:resource_name/:id (show)" do
+      it "renders email as mailto link" do
+        user = create(:user, email: "test@example.com")
+        get command_post.resource_path("users", user), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('href="mailto:test@example.com"')
+      end
+
+      it "handles blank email gracefully" do
+        user = create(:user)
+        allow_any_instance_of(User).to receive(:email).and_return("") # rubocop:disable RSpec/AnyInstance
+        get command_post.resource_path("users", user), as: :html
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /:resource_name/new" do
+      it "renders form with email input" do
+        get command_post.new_resource_path("users"), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('type="email"')
+        expect(response.body).to include("user@example.com")
+      end
+    end
+  end
+
+  describe "color field type" do
+    describe "GET /:resource_name/:id (show)" do
+      it "renders color swatch with hex code" do
+        profile = create(:profile, color_hex: "#3b82f6")
+        get command_post.resource_path("profiles", profile), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("#3b82f6")
+        expect(response.body).to include("background-color:")
+      end
+
+      it "handles blank color gracefully" do
+        profile = create(:profile, color_hex: "")
+        get command_post.resource_path("profiles", profile), as: :html
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "handles nil color gracefully" do
+        profile = create(:profile, color_hex: nil)
+        get command_post.resource_path("profiles", profile), as: :html
+
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    describe "GET /:resource_name/new" do
+      it "renders form with color picker" do
+        get command_post.new_resource_path("profiles"), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('type="color"')
+      end
+    end
+
+    describe "POST /:resource_name (create)" do
+      it "creates record with color field" do
+        user = create(:user)
+        post command_post.resources_path("profiles"),
+             params: { record: { user_id: user.id, color_hex: "#ff5733" } },
+             as: :html
+
+        expect(Profile.last.color_hex).to eq("#ff5733")
+      end
+    end
+  end
+
+  describe "currency field type" do
+    describe "GET /:resource_name/:id (show)" do
+      it "renders currency with symbol and formatting" do
+        profile = create(:profile, hourly_rate: 1234.56)
+        get command_post.resource_path("profiles", profile), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("$")
+        expect(response.body).to include("1,234.56")
+        expect(response.body).to include("tabular-nums")
+      end
+
+      it "handles nil value gracefully" do
+        profile = create(:profile, hourly_rate: nil)
+        get command_post.resource_path("profiles", profile), as: :html
+
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "handles zero value" do
+        profile = create(:profile, hourly_rate: 0)
+        get command_post.resource_path("profiles", profile), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("$0.00")
+      end
+    end
+
+    describe "GET /:resource_name/new" do
+      it "renders form with currency input" do
+        get command_post.new_resource_path("profiles"), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('step="0.01"')
+        expect(response.body).to include("$")
+      end
+    end
+
+    describe "POST /:resource_name (create)" do
+      it "creates record with currency field" do
+        user = create(:user)
+        post command_post.resources_path("profiles"),
+             params: { record: { user_id: user.id, hourly_rate: "99.99" } },
+             as: :html
+
+        expect(Profile.last.hourly_rate).to eq(99.99)
+      end
+    end
+  end
+
+  describe "boolean smart rendering" do
+    describe "GET /:resource_name/:id (show)" do
+      it "renders true as green checkmark icon" do
+        user = create(:user, active: true)
+        get command_post.resource_path("users", user), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("text-green-500")
+      end
+
+      it "renders false as red X icon" do
+        user = create(:user, active: false)
+        get command_post.resource_path("users", user), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("text-red-400")
+      end
+    end
+
+    describe "GET /:resource_name (index)" do
+      it "renders boolean icons on index page" do
+        create(:user, active: true)
+        create(:user, active: false)
+        get command_post.resources_path("users"), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("text-green-500")
+        expect(response.body).to include("text-red-400")
+      end
+    end
+  end
+
+  describe "date/datetime formatting" do
+    describe "GET /:resource_name/:id (show)" do
+      it "formats datetime in human-readable format" do
+        user = create(:user)
+        get command_post.resource_path("users", user), as: :html
+
+        expect(response).to have_http_status(:ok)
+        # created_at should be formatted like "Feb 10, 2026 at 3:45 PM"
+        expect(response.body).to match(/\w{3} \d{1,2}, \d{4} at/)
+      end
+    end
+
+    describe "GET /:resource_name (index)" do
+      it "formats datetime on index page" do
+        create(:user)
+        get command_post.resources_path("users"), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to match(/\w{3} \d{1,2}, \d{4} at/)
+      end
+    end
+  end
+
+  describe "text truncation on index" do
+    describe "GET /:resource_name (index)" do
+      it "truncates long text on index page" do
+        long_bio = "A" * 100
+        user = create(:user)
+        create(:profile, user: user, bio: long_bio)
+        get command_post.resources_path("profiles"), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("...")
+        expect(response.body).to include("title=")
+      end
+
+      it "does not truncate short text" do
+        user = create(:user)
+        create(:profile, user: user, bio: "Short bio")
+        get command_post.resources_path("profiles"), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Short bio")
+      end
+    end
+
+    describe "GET /:resource_name/:id (show)" do
+      it "shows full text on show page" do
+        long_bio = "A" * 100
+        user = create(:user)
+        profile = create(:profile, user: user, bio: long_bio)
+        get command_post.resource_path("profiles", profile), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(long_bio)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- **URL field type** (`type: :url`): Clickable links with external icon, `type="url"` form input, auto-inferred for `*_url`, `*_link`, `website` columns
- **Email field type** (`type: :email`): Mailto links, `type="email"` form input, auto-inferred for `email`, `*_email` columns
- **Color field type** (`type: :color`): Color swatch + hex code display, native color picker on forms
- **Currency field type** (`type: :currency`): Formatted with symbol, thousands separators, decimals; configurable via `options: { symbol: "$", precision: 2 }`
- **Boolean smart rendering**: Green checkmark icon for true, red X icon for false (replaces raw true/false text)
- **Date/datetime formatting**: Human-readable dates ("Jan 15, 2024") and datetimes ("Jan 15, 2024 at 3:45 PM"), configurable format
- **Text truncation on index**: Auto-truncates text/textarea fields to 50 chars with hover tooltip for full text

## Test plan

- [x] 1089 examples, 0 failures
- [x] 97.01% line coverage (above 95% threshold)
- [x] RuboCop clean on all gem files (0 offenses)
- [x] URL: clickable links, blank/nil handling, form input, create
- [x] Email: mailto links, blank handling, form input
- [x] Color: swatch display, blank/nil handling, form picker, create
- [x] Currency: formatted display, nil/zero handling, form input, create
- [x] Boolean: green check / red X icons on show and index
- [x] Date/datetime: human-friendly formatting on show and index
- [x] Text truncation: long text truncated on index, full text on show
- [x] FieldInferrer: auto-detects URL and email columns by naming convention

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)