### PR TITLE
Switch gem publishing to RubyGems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4
@@ -42,8 +41,7 @@ jobs:
       - name: Build gem
         run: gem build iron_admin.gemspec
 
-      - name: Publish to GitHub Packages
+      - name: Publish to RubyGems
         env:
-          GEM_HOST_API_KEY: Bearer ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gem push --host https://rubygems.pkg.github.com/RubyLabApp *.gem
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: gem push *.gem


### PR DESCRIPTION
## Summary
- Replace GitHub Packages publishing with RubyGems in the release workflow
- Remove `packages: write` permission (no longer needed)
- Use `RUBYGEMS_API_KEY` secret instead of `GITHUB_TOKEN`

## Test plan
- [ ] Verify `RUBYGEMS_API_KEY` secret is configured in repo settings
- [ ] Trigger a release to confirm publishing works

🤖 Generated with [Claude Code](https://claude.com/claude-code)