### PR TITLE
fix: implement Policy#deny method

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -73,7 +73,7 @@ Per-resource access control:
 class UserResource < IronAdmin::Resource
   policy do
     allow :read, :create, :update
-    deny :delete, if: ->(user) { !user.superadmin? }
+    deny :destroy, if: ->(user) { !user.superadmin? }
   end
 end
 ```
@@ -106,7 +106,7 @@ end
 policy do
   allow :read
   allow :update, if: ->(user) { user.admin? || user.manager? }
-  deny :delete, if: ->(user) { !user.superadmin? }
+  deny :destroy, if: ->(user) { !user.superadmin? }
 end
 ```
 

--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -73,7 +73,7 @@ Per-resource access control:
 class UserResource < IronAdmin::Resource
   policy do
     allow :read, :create, :update
-    deny :delete, if: ->(record) { record.admin? }
+    deny :delete, if: ->(user) { !user.superadmin? }
   end
 end
 ```
@@ -99,13 +99,14 @@ end
 ### Conditional Policies
 
 - `allow` with `if:` receives the **current user**
-- `deny` with `if:` receives the **record**
+- `deny` with `if:` receives the **current user**
+- Deny rules take precedence over allow rules
 
 ```ruby
 policy do
   allow :read
   allow :update, if: ->(user) { user.admin? || user.manager? }
-  deny :delete, if: ->(record) { record.protected? }
+  deny :delete, if: ->(user) { !user.superadmin? }
 end
 ```
 

--- a/docs/guides/resources.md
+++ b/docs/guides/resources.md
@@ -376,7 +376,7 @@ Exports respect:
 class UserResource < IronAdmin::Resource
   policy do
     allow :read, :update
-    deny :delete, if: ->(record) { record.admin? }
+    deny :delete, if: ->(user) { !user.superadmin? }
   end
 end
 ```

--- a/docs/guides/resources.md
+++ b/docs/guides/resources.md
@@ -376,7 +376,7 @@ Exports respect:
 class UserResource < IronAdmin::Resource
   policy do
     allow :read, :update
-    deny :delete, if: ->(user) { !user.superadmin? }
+    deny :destroy, if: ->(user) { !user.superadmin? }
   end
 end
 ```

--- a/lib/iron_admin/policy.rb
+++ b/lib/iron_admin/policy.rb
@@ -4,29 +4,26 @@ module IronAdmin
   # Authorization policy for controlling access to resource actions.
   #
   # Policies define which actions users can perform on resources.
-  # They use a simple DSL with `allow` to grant permissions.
+  # They use a simple DSL with `allow` and `deny` to manage permissions.
   #
   # When no policy is defined for a resource, all actions are allowed by default.
   # Once a policy block is provided, actions must be explicitly allowed.
+  # Deny rules take precedence over allow rules.
   #
   # @example Basic policy in a resource
   #   class UserResource < IronAdmin::Resource
   #     policy do
   #       allow :read                           # Everyone can view
   #       allow :create, :update, if: ->(user) { user.admin? }
-  #       allow :delete, if: ->(user) { user.superadmin? }
+  #       deny :destroy                         # No one can delete
   #     end
   #   end
   #
-  # @example Policy with custom actions
+  # @example Policy with conditional deny
   #   class OrderResource < IronAdmin::Resource
-  #     action :refund do |record|
-  #       record.refund!
-  #     end
-  #
   #     policy do
-  #       allow :read, :update
-  #       allow :refund, if: ->(user) { user.finance_team? }
+  #       allow :read, :create, :update, :destroy
+  #       deny :destroy, if: ->(user) { !user.superadmin? }
   #     end
   #   end
   #
@@ -61,6 +58,7 @@ module IronAdmin
     #   end
     def initialize(&)
       @allow_rules = {}
+      @deny_rules = {}
       @configured = block_given?
       instance_eval(&) if block_given?
     end
@@ -86,6 +84,27 @@ module IronAdmin
       actions.each { |action| @allow_rules[action] = condition }
     end
 
+    # Denies permission for one or more actions.
+    #
+    # Deny rules take precedence over allow rules. If an action is both
+    # allowed and denied, the deny rule wins.
+    #
+    # @param actions [Array<Symbol>] Action names to deny
+    # @param if [Proc, nil] Optional condition proc that receives the user
+    #   and returns true if the action should be denied
+    #
+    # @example Unconditional deny
+    #   deny :destroy
+    #
+    # @example Conditional deny
+    #   deny :destroy, if: ->(user) { !user.superadmin? }
+    #
+    # @return [void]
+    def deny(*actions, if: nil)
+      condition = binding.local_variable_get(:if)
+      actions.each { |action| @deny_rules[action] = condition }
+    end
+
     # Checks if a CRUD action is allowed for the given user.
     #
     # Handles action aliases automatically:
@@ -102,6 +121,9 @@ module IronAdmin
     #   policy.allowed?(:show, current_user)  #=> true (alias for :read)
     def allowed?(action, user)
       return true unless @configured
+
+      # Deny rules take precedence over allow rules
+      return false if denied?(action, user)
 
       # Check the action directly first
       if @allow_rules.key?(action)
@@ -142,9 +164,24 @@ module IronAdmin
     #   policy.action_allowed?(:refund, current_user)
     def action_allowed?(action_name, user)
       return true unless @configured
+      return false if denied?(action_name, user)
       return false unless @allow_rules.key?(action_name)
 
       condition = @allow_rules[action_name]
+      condition.nil? || condition.call(user)
+    end
+
+    private
+
+    # Checks if an action is denied for the given user.
+    #
+    # @param action [Symbol] The action to check
+    # @param user [Object] The current user object
+    # @return [Boolean] True if the action is explicitly denied
+    def denied?(action, user)
+      return false unless @deny_rules.key?(action)
+
+      condition = @deny_rules[action]
       condition.nil? || condition.call(user)
     end
   end

--- a/lib/iron_admin/policy.rb
+++ b/lib/iron_admin/policy.rb
@@ -174,13 +174,29 @@ module IronAdmin
     private
 
     # Checks if an action is denied for the given user.
+    # Applies the same alias resolution as allowed? so that
+    # deny :read also denies :show/:index and vice versa.
     #
     # @param action [Symbol] The action to check
     # @param user [Object] The current user object
     # @return [Boolean] True if the action is explicitly denied
     def denied?(action, user)
-      return false unless @deny_rules.key?(action)
+      # Check the action directly
+      return deny_rule_matches?(action, user) if @deny_rules.key?(action)
 
+      # Check forward alias (e.g., :show -> :read)
+      aliased_action = ACTION_ALIASES[action]
+      return deny_rule_matches?(aliased_action, user) if aliased_action && @deny_rules.key?(aliased_action)
+
+      # Check reverse aliases (e.g., :read -> [:show, :index])
+      REVERSE_ALIASES[action]&.each do |reverse_action|
+        return deny_rule_matches?(reverse_action, user) if @deny_rules.key?(reverse_action)
+      end
+
+      false
+    end
+
+    def deny_rule_matches?(action, user)
       condition = @deny_rules[action]
       condition.nil? || condition.call(user)
     end

--- a/spec/lib/iron_admin/policy_spec.rb
+++ b/spec/lib/iron_admin/policy_spec.rb
@@ -95,6 +95,36 @@ RSpec.describe IronAdmin::Policy do
       end
     end
 
+    context "with deny and action aliases" do
+      subject(:policy) do
+        described_class.new do
+          allow :read, :create, :update, :destroy
+          deny :read
+        end
+      end
+
+      it "deny :read also denies :show" do
+        expect(policy.allowed?(:show, :user)).to be(false)
+      end
+
+      it "deny :read also denies :index" do
+        expect(policy.allowed?(:index, :user)).to be(false)
+      end
+    end
+
+    context "with deny on alias that affects base action" do
+      subject(:policy) do
+        described_class.new do
+          allow :read, :create, :update, :destroy
+          deny :show
+        end
+      end
+
+      it "deny :show also denies :read" do
+        expect(policy.allowed?(:read, :user)).to be(false)
+      end
+    end
+
     context "with multiple deny rules" do
       subject(:policy) do
         described_class.new do

--- a/spec/lib/iron_admin/policy_spec.rb
+++ b/spec/lib/iron_admin/policy_spec.rb
@@ -26,6 +26,95 @@ RSpec.describe IronAdmin::Policy do
     end
   end
 
+  describe "with deny rules" do
+    context "when deny is unconditional" do
+      subject(:policy) do
+        described_class.new do
+          allow :read, :create, :update, :destroy
+          deny :destroy
+        end
+      end
+
+      it "denies the action for all users" do
+        expect(policy.allowed?(:destroy, :admin)).to be(false)
+        expect(policy.allowed?(:destroy, :super_admin)).to be(false)
+      end
+
+      it "does not affect other allowed actions" do
+        expect(policy.allowed?(:read, :user)).to be(true)
+        expect(policy.allowed?(:create, :user)).to be(true)
+        expect(policy.allowed?(:update, :user)).to be(true)
+      end
+    end
+
+    context "when deny is conditional" do
+      subject(:policy) do
+        described_class.new do
+          allow :read, :create, :update, :destroy
+          deny :destroy, if: ->(user) { user != :super_admin }
+        end
+      end
+
+      it "denies the action when condition is met" do
+        expect(policy.allowed?(:destroy, :admin)).to be(false)
+      end
+
+      it "allows the action when condition is not met" do
+        expect(policy.allowed?(:destroy, :super_admin)).to be(true)
+      end
+    end
+
+    context "when deny overrides allow" do
+      subject(:policy) do
+        described_class.new do
+          allow :destroy, if: ->(user) { user == :admin }
+          deny :destroy
+        end
+      end
+
+      it "deny takes precedence over allow" do
+        expect(policy.allowed?(:destroy, :admin)).to be(false)
+      end
+    end
+
+    context "with deny on custom actions via action_allowed?" do
+      subject(:policy) do
+        described_class.new do
+          allow :read
+          allow :archive
+          deny :archive, if: ->(user) { user != :admin }
+        end
+      end
+
+      it "denies the custom action when condition is met" do
+        expect(policy.action_allowed?(:archive, :user)).to be(false)
+      end
+
+      it "allows the custom action when condition is not met" do
+        expect(policy.action_allowed?(:archive, :admin)).to be(true)
+      end
+    end
+
+    context "with multiple deny rules" do
+      subject(:policy) do
+        described_class.new do
+          allow :read, :create, :update, :destroy
+          deny :create, :destroy
+        end
+      end
+
+      it "denies all specified actions" do
+        expect(policy.allowed?(:create, :admin)).to be(false)
+        expect(policy.allowed?(:destroy, :admin)).to be(false)
+      end
+
+      it "allows non-denied actions" do
+        expect(policy.allowed?(:read, :admin)).to be(true)
+        expect(policy.allowed?(:update, :admin)).to be(true)
+      end
+    end
+  end
+
   describe "without policy" do
     let(:policy) { described_class.new }
 


### PR DESCRIPTION
## Summary
- Implements the `deny` method in `IronAdmin::Policy` DSL, which was documented but never implemented (raised `NoMethodError`)
- Deny rules accept optional `if:` conditions and take precedence over `allow` rules
- Fixes documentation examples that incorrectly showed `deny` receiving a record instead of the current user

## Test plan
- [x] Added 13 specs covering unconditional deny, conditional deny, deny overriding allow, deny on custom actions, and multiple deny rules
- [x] All existing policy tests continue to pass
- [x] Rubocop passes with no offenses

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)