### PR TITLE
fix: allow custom actions by default when policy is configured

### DIFF
--- a/docs/guides/authentication.md
+++ b/docs/guides/authentication.md
@@ -111,7 +111,7 @@ end
 
 ### Custom Action Authorization
 
-Custom actions and bulk actions require explicit policy permission:
+Custom actions and bulk actions are **allowed by default**, even when a policy is defined. This separates custom action authorization from CRUD policy. To restrict a custom action, add an `allow` rule with a condition:
 
 ```ruby
 class UserResource < IronAdmin::Resource
@@ -125,8 +125,8 @@ class UserResource < IronAdmin::Resource
 
   policy do
     allow :read, :update
-    allow :lock      # Authorize the custom action
-    allow :archive   # Authorize the bulk action
+    allow :lock, if: ->(user) { user.admin? }      # Restrict the custom action
+    allow :archive, if: ->(user) { user.admin? }    # Restrict the bulk action
   end
 end
 ```

--- a/lib/iron_admin/policy.rb
+++ b/lib/iron_admin/policy.rb
@@ -146,9 +146,11 @@ module IronAdmin
     #   policy.action_allowed?(:refund, current_user)
     def action_allowed?(action_name, user)
       return true unless @configured
-      return true unless @allow_rules.key?(action_name)
 
-      condition = @allow_rules[action_name]
+      action = action_name.to_sym
+      return true unless @allow_rules.key?(action)
+
+      condition = @allow_rules[action]
       condition.nil? || condition.call(user)
     end
   end

--- a/lib/iron_admin/policy.rb
+++ b/lib/iron_admin/policy.rb
@@ -131,18 +131,22 @@ module IronAdmin
     # Checks if a custom action (or bulk action) is allowed.
     #
     # Unlike {#allowed?}, this does not use action aliases.
-    # Custom actions must be explicitly allowed by name.
+    # Custom actions are allowed by default unless explicitly restricted
+    # via an `allow` rule with a condition. This separates custom action
+    # authorization from CRUD policy — custom actions are not gated by
+    # the CRUD allowlist.
     #
     # @param action_name [Symbol] The custom action name
     # @param user [Object] The current user object
     #
-    # @return [Boolean] True if the action is allowed, or if no policy is configured
+    # @return [Boolean] True if the action is allowed, or if no policy is configured,
+    #   or if the action has no explicit rule
     #
     # @example
     #   policy.action_allowed?(:refund, current_user)
     def action_allowed?(action_name, user)
       return true unless @configured
-      return false unless @allow_rules.key?(action_name)
+      return true unless @allow_rules.key?(action_name)
 
       condition = @allow_rules[action_name]
       condition.nil? || condition.call(user)

--- a/spec/lib/iron_admin/policy_spec.rb
+++ b/spec/lib/iron_admin/policy_spec.rb
@@ -26,6 +26,63 @@ RSpec.describe IronAdmin::Policy do
     end
   end
 
+  describe "#action_allowed?" do
+    context "when custom action is not in allow rules" do
+      subject(:policy) do
+        described_class.new do
+          allow :read
+          allow :create, :update, if: ->(user) { user == :admin }
+        end
+      end
+
+      it "allows custom actions by default" do
+        expect(policy.action_allowed?(:archive, :user)).to be(true)
+      end
+
+      it "allows bulk actions by default" do
+        expect(policy.action_allowed?(:bulk_archive, :user)).to be(true)
+      end
+    end
+
+    context "when custom action has a conditional allow rule" do
+      subject(:policy) do
+        described_class.new do
+          allow :read
+          allow :archive, if: ->(user) { user == :admin }
+        end
+      end
+
+      it "allows when condition is met" do
+        expect(policy.action_allowed?(:archive, :admin)).to be(true)
+      end
+
+      it "denies when condition is not met" do
+        expect(policy.action_allowed?(:archive, :user)).to be(false)
+      end
+    end
+
+    context "when custom action has an unconditional allow rule" do
+      subject(:policy) do
+        described_class.new do
+          allow :read
+          allow :archive
+        end
+      end
+
+      it "allows the action for all users" do
+        expect(policy.action_allowed?(:archive, :anyone)).to be(true)
+      end
+    end
+
+    context "when no policy is configured" do
+      subject(:policy) { described_class.new }
+
+      it "allows all custom actions" do
+        expect(policy.action_allowed?(:archive, :anyone)).to be(true)
+      end
+    end
+  end
+
   describe "without policy" do
     let(:policy) { described_class.new }
 

--- a/spec/lib/iron_admin/policy_spec.rb
+++ b/spec/lib/iron_admin/policy_spec.rb
@@ -59,6 +59,11 @@ RSpec.describe IronAdmin::Policy do
       it "denies when condition is not met" do
         expect(policy.action_allowed?(:archive, :user)).to be(false)
       end
+
+      it "handles string action names by normalizing to symbol" do
+        expect(policy.action_allowed?("archive", :admin)).to be(true)
+        expect(policy.action_allowed?("archive", :user)).to be(false)
+      end
     end
 
     context "when custom action has an unconditional allow rule" do

--- a/spec/requests/iron_admin/resources_spec.rb
+++ b/spec/requests/iron_admin/resources_spec.rb
@@ -1700,7 +1700,7 @@ RSpec.describe "IronAdmin::Resources", type: :request do
           allow :create, :update, :destroy, if: ->(user) { user&.role == "admin" }
           allow :revoke, if: ->(user) { user&.role == "admin" }
           allow :bulk_revoke, if: ->(user) { user&.role == "admin" }
-          # renew and bulk_export are not allowed by policy
+          # renew and bulk_export are not in the allow list but are allowed by default
         end
       end
     end
@@ -1730,9 +1730,9 @@ RSpec.describe "IronAdmin::Resources", type: :request do
         expect(response).to have_http_status(:forbidden)
       end
 
-      it "returns forbidden for actions not in policy allow list" do
+      it "allows actions not in policy allow list by default" do
         post iron_admin.resource_action_path("policy_licenses", license, "renew"), as: :html
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to redirect_to(iron_admin.resource_path("policy_licenses", license))
       end
 
       it "does not execute the action when forbidden" do
@@ -1757,9 +1757,9 @@ RSpec.describe "IronAdmin::Resources", type: :request do
         expect(license.reload.status).to eq("revoked")
       end
 
-      it "returns forbidden for actions not in policy allow list even for admin" do
+      it "allows actions not in policy allow list for admin" do
         post iron_admin.resource_action_path("policy_licenses", license, "renew"), as: :html
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to redirect_to(iron_admin.resource_path("policy_licenses", license))
       end
     end
 
@@ -1841,11 +1841,11 @@ RSpec.describe "IronAdmin::Resources", type: :request do
         expect(response).to have_http_status(:forbidden)
       end
 
-      it "returns forbidden for bulk actions not in policy allow list" do
+      it "allows bulk actions not in policy allow list by default" do
         post iron_admin.resource_bulk_action_path("policy_licenses", "bulk_export"),
              params: { ids: licenses.map(&:id) },
              as: :html
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to redirect_to(iron_admin.resources_path("policy_licenses"))
       end
 
       it "does not execute the bulk action when forbidden" do
@@ -1878,11 +1878,11 @@ RSpec.describe "IronAdmin::Resources", type: :request do
         end
       end
 
-      it "returns forbidden for bulk actions not in policy allow list even for admin" do
+      it "allows bulk actions not in policy allow list for admin" do
         post iron_admin.resource_bulk_action_path("policy_licenses", "bulk_export"),
              params: { ids: licenses.map(&:id) },
              as: :html
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to redirect_to(iron_admin.resources_path("policy_licenses"))
       end
     end
 


### PR DESCRIPTION
## Summary
- Custom actions (`action`/`bulk_action`) were blocked with 403 when a `policy` block was defined, because `action_allowed?` returned false for actions not in `@allow_rules`
- Changed `action_allowed?` to return `true` by default for actions without explicit rules, separating custom action authorization from CRUD policy
- Updated authentication docs to reflect that custom actions are allowed by default

## Test plan
- [x] Added tests for `action_allowed?` covering: custom actions not in rules (allowed), conditional allow rules, unconditional allow rules, and no-policy scenarios
- [x] All 10 policy specs pass
- [x] Rubocop passes with no offenses

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)