### PR TITLE
fix: constantize string resource values in association methods

### DIFF
--- a/lib/iron_admin/resource.rb
+++ b/lib/iron_admin/resource.rb
@@ -604,10 +604,10 @@ module IronAdmin
           reflection = adapter.association(assoc_name)
           next unless reflection
 
-          resource = ResourceRegistry.find(reflection.klass.model_name.plural)
+          resource = resolve_association_resource(config, reflection)
           next unless resource
 
-          { name: assoc_name, reflection: reflection, resource: resource, **config.except(:kind) }
+          { name: assoc_name, reflection: reflection, resource: resource, **config.except(:kind, :resource) }
         end
       end
 
@@ -621,10 +621,10 @@ module IronAdmin
           reflection = adapter.association(assoc_name)
           next unless reflection
 
-          resource = ResourceRegistry.find(reflection.klass.model_name.plural)
+          resource = resolve_association_resource(config, reflection)
           next unless resource
 
-          { name: assoc_name, reflection: reflection, resource: resource, **config.except(:kind) }
+          { name: assoc_name, reflection: reflection, resource: resource, **config.except(:kind, :resource) }
         end
       end
 
@@ -638,9 +638,9 @@ module IronAdmin
           reflection = adapter.association(assoc_name)
           next unless reflection
 
-          resource = ResourceRegistry.find(reflection.klass.model_name.plural)
+          resource = resolve_association_resource(config, reflection)
 
-          { name: assoc_name, reflection: reflection, resource: resource, **config.except(:kind) }
+          { name: assoc_name, reflection: reflection, resource: resource, **config.except(:kind, :resource) }
         end
       end
 
@@ -718,6 +718,16 @@ module IronAdmin
       private_constant :SKIP_FILTER_COLUMNS
 
       private
+
+      # Resolves the resource class for an association configuration.
+      # Accepts Class, String, or falls back to ResourceRegistry lookup.
+      def resolve_association_resource(config, reflection)
+        resource = config[:resource]
+        return resource.constantize if resource.is_a?(String)
+        return resource if resource
+
+        ResourceRegistry.find(reflection.klass.model_name.plural)
+      end
 
       def enum_auto_filters
         adapter.enums.map do |name, values|

--- a/spec/lib/iron_admin/resource_spec.rb
+++ b/spec/lib/iron_admin/resource_spec.rb
@@ -394,6 +394,18 @@ RSpec.describe IronAdmin::Resource do
       expect(profile_assoc[:resource]).to eq(IronAdmin::Resources::ProfileResource)
     end
 
+    it "resolves has_one associations when resource is a string" do
+      resource_class = Class.new(IronAdmin::Resource) do
+        self.model_class_override = User
+        has_one :profile, resource: "IronAdmin::Resources::ProfileResource"
+      end
+
+      associations = resource_class.has_one_associations
+      profile_assoc = associations.find { |a| a[:name] == :profile }
+      expect(profile_assoc).to be_present
+      expect(profile_assoc[:resource]).to eq(IronAdmin::Resources::ProfileResource)
+    end
+
     it "returns empty for has_one when no associations defined" do
       IronAdmin::ResourceRegistry.reset!
       IronAdmin::ResourceRegistry.register(TestLicenseResource)
@@ -404,6 +416,18 @@ RSpec.describe IronAdmin::Resource do
     it "stores has_and_belongs_to_many declarations" do
       assoc = IronAdmin::Resources::PostResource.defined_associations[:tags]
       expect(assoc[:kind]).to eq(:has_and_belongs_to_many)
+    end
+
+    it "resolves habtm associations when resource is a string" do
+      resource_class = Class.new(IronAdmin::Resource) do
+        self.model_class_override = Post
+        has_and_belongs_to_many :tags, resource: "IronAdmin::Resources::TagResource"
+      end
+
+      associations = resource_class.habtm_associations
+      tags_assoc = associations.find { |a| a[:name] == :tags }
+      expect(tags_assoc).to be_present
+      expect(tags_assoc[:resource]).to eq(IronAdmin::Resources::TagResource)
     end
 
     it "resolves habtm associations with reflection" do

--- a/spec/lib/iron_admin/resource_spec.rb
+++ b/spec/lib/iron_admin/resource_spec.rb
@@ -359,6 +359,30 @@ RSpec.describe IronAdmin::Resource do
       expect(licenses_assoc[:resource]).to eq(TestLicenseResource)
     end
 
+    it "resolves has_many associations when resource is a string" do
+      resource_class = Class.new(IronAdmin::Resource) do
+        self.model_class_override = User
+        has_many :licenses, resource: "IronAdmin::Resources::LicenseResource"
+      end
+
+      associations = resource_class.has_many_associations
+      licenses_assoc = associations.find { |a| a[:name] == :licenses }
+      expect(licenses_assoc).to be_present
+      expect(licenses_assoc[:resource]).to eq(IronAdmin::Resources::LicenseResource)
+    end
+
+    it "resolves has_many associations when resource is a class" do
+      resource_class = Class.new(IronAdmin::Resource) do
+        self.model_class_override = User
+        has_many :licenses, resource: IronAdmin::Resources::LicenseResource
+      end
+
+      associations = resource_class.has_many_associations
+      licenses_assoc = associations.find { |a| a[:name] == :licenses }
+      expect(licenses_assoc).to be_present
+      expect(licenses_assoc[:resource]).to eq(IronAdmin::Resources::LicenseResource)
+    end
+
     it "resolves has_one associations with resource and reflection" do
       IronAdmin::ResourceRegistry.reset!
       IronAdmin::ResourceRegistry.register(TestUserResource)


### PR DESCRIPTION
## Summary
- `has_many`, `has_one`, and `habtm` association methods crashed with `NoMethodError` when `resource:` was passed as a string (e.g., `"IronAdmin::Resources::ProjectResource"`)
- Added `resolve_association_resource` helper that handles String (constantize), Class (direct use), and nil (registry fallback)
- Applied the fix to all three association methods

## Test plan
- [x] Added tests for string and class `resource:` options on `has_many`
- [x] All 88 resource specs pass
- [x] Rubocop passes with no offenses

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)