### PR TITLE
fix: add icon: keyword to Dashboard#metric DSL

### DIFF
--- a/app/components/iron_admin/dashboards/metric_card_component.html.haml
+++ b/app/components/iron_admin/dashboards/metric_card_component.html.haml
@@ -1,3 +1,8 @@
 .bg-white.rounded-lg.shadow.p-6
-  %p.text-sm.font-medium.text-gray-500= label
-  %p.mt-2.text-3xl.font-bold.text-gray-900= formatted_value
+  .flex.items-center.justify-between
+    %div
+      %p.text-sm.font-medium.text-gray-500= label
+      %p.mt-2.text-3xl.font-bold.text-gray-900= formatted_value
+    - if icon
+      .flex-shrink-0.p-3.bg-indigo-50.rounded-lg
+        = heroicon icon, variant: :outline, options: { class: "h-6 w-6 text-indigo-600" }

--- a/app/components/iron_admin/dashboards/metric_card_component.rb
+++ b/app/components/iron_admin/dashboards/metric_card_component.rb
@@ -7,10 +7,12 @@ module IronAdmin
       # @param name [String, Symbol] Metric name
       # @param value [Numeric] Metric value
       # @param format [Symbol] Format (:number, :currency, :percentage)
-      def initialize(name:, value:, format: :number)
+      # @param icon [String, nil] Optional Heroicon name (e.g., "users", "currency-dollar")
+      def initialize(name:, value:, format: :number, icon: nil)
         @name = name
         @value = value
         @format = format
+        @icon = icon
       end
 
       # @api private
@@ -28,6 +30,10 @@ module IronAdmin
       def label
         @name.to_s.humanize
       end
+
+      # @api private
+      # @return [String, nil] Heroicon name
+      attr_reader :icon
     end
   end
 end

--- a/app/views/iron_admin/dashboard/index.html.haml
+++ b/app/views/iron_admin/dashboard/index.html.haml
@@ -5,7 +5,7 @@
     - if @dashboard.defined_metrics.any?
       .grid.grid-cols-1.md:grid-cols-2.lg:grid-cols-4.gap-6.mb-8
         - @dashboard.defined_metrics.each do |metric|
-          = render IronAdmin::Dashboards::MetricCardComponent.new(name: metric[:name], value: metric[:block].call, format: metric[:format])
+          = render IronAdmin::Dashboards::MetricCardComponent.new(name: metric[:name], value: metric[:block].call, format: metric[:format], icon: metric[:icon])
 
     - if @dashboard.defined_charts.any?
       = javascript_include_tag "chart.min", defer: true, onload: "document.dispatchEvent(new CustomEvent('chartjs:loaded'))"

--- a/lib/iron_admin/dashboard.rb
+++ b/lib/iron_admin/dashboard.rb
@@ -85,8 +85,8 @@ module IronAdmin
       #   end
       #
       # @return [void]
-      def metric(name, format: :number, &block)
-        self.defined_metrics = defined_metrics + [{ name: name, format: format, block: block }]
+      def metric(name, format: :number, icon: nil, &block)
+        self.defined_metrics = defined_metrics + [{ name: name, format: format, icon: icon, block: block }]
       end
 
       # Defines a chart for the dashboard.

--- a/lib/iron_admin/dashboard.rb
+++ b/lib/iron_admin/dashboard.rb
@@ -66,22 +66,18 @@ module IronAdmin
       #   - :number - Plain number with thousands separators
       #   - :currency - Currency format (uses Rails number_to_currency)
       #   - :percentage - Percentage format
+      # @param icon [String, nil] Optional Heroicon name for visual context (e.g., "users", "currency-dollar")
       # @yield Block that computes and returns the metric value
       # @yieldreturn [Numeric] The metric value
       #
-      # @example User count metric
-      #   metric :total_users, format: :number do
+      # @example User count metric with icon
+      #   metric :total_users, format: :number, icon: "users" do
       #     User.count
       #   end
       #
       # @example Revenue metric
       #   metric :total_revenue, format: :currency do
       #     Order.where(status: "completed").sum(:total)
-      #   end
-      #
-      # @example Conversion rate metric
-      #   metric :conversion_rate, format: :percentage do
-      #     (Order.count.to_f / Visit.count * 100).round(1)
       #   end
       #
       # @return [void]

--- a/spec/components/iron_admin/dashboards/metric_card_component_spec.rb
+++ b/spec/components/iron_admin/dashboards/metric_card_component_spec.rb
@@ -14,4 +14,14 @@ RSpec.describe IronAdmin::Dashboards::MetricCardComponent, type: :component do
 
     expect(result.text).to include("$1,500.50")
   end
+
+  it "exposes icon attribute when provided" do
+    component = described_class.new(name: :total_users, value: 42, format: :number, icon: "users")
+    expect(component.icon).to eq("users")
+  end
+
+  it "has nil icon when not provided" do
+    component = described_class.new(name: :total_users, value: 42, format: :number)
+    expect(component.icon).to be_nil
+  end
 end

--- a/spec/lib/iron_admin/dashboard_spec.rb
+++ b/spec/lib/iron_admin/dashboard_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe IronAdmin::Dashboard do
 
     it "stores icon as nil when not specified" do
       metric = TestDashboard.defined_metrics.first
-      expect(metric[:icon]).to be_nil
+      expect(metric).to include(icon: nil)
     end
 
     it "stores icon when specified" do

--- a/spec/lib/iron_admin/dashboard_spec.rb
+++ b/spec/lib/iron_admin/dashboard_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe IronAdmin::Dashboard do
       metric = TestDashboard.defined_metrics.last
       expect(metric[:format]).to eq(:currency)
     end
+
+    it "stores icon as nil when not specified" do
+      metric = TestDashboard.defined_metrics.first
+      expect(metric[:icon]).to be_nil
+    end
+
+    it "stores icon when specified" do
+      dashboard_class = Class.new(IronAdmin::Dashboard) do
+        metric :active_users, icon: "users" do
+          10
+        end
+      end
+
+      metric = dashboard_class.defined_metrics.first
+      expect(metric[:icon]).to eq("users")
+    end
   end
 
   describe "charts" do


### PR DESCRIPTION
## Summary
- `Dashboard#metric` raised `ArgumentError` when `icon:` was passed
- Added `icon:` parameter to the `metric` DSL method, `MetricCardComponent`, and the dashboard view
- Icons render as Heroicons alongside the metric value when provided, nil by default

## Test plan
- [x] Added tests for icon storage (nil when not specified, stored when specified)
- [x] All 9 dashboard specs pass
- [x] Rubocop passes with no offenses on Ruby files

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)