### PR TITLE
fix: add label: keyword to Dashboard#chart DSL

### DIFF
--- a/app/views/iron_admin/dashboard/index.html.haml
+++ b/app/views/iron_admin/dashboard/index.html.haml
@@ -14,7 +14,7 @@
           - chart_data = chart[:block].call
           - labels = chart_data.keys
           - data = chart_data.values
-          = render IronAdmin::Dashboards::ChartComponent.new(title: chart[:name].to_s.humanize, type: chart[:type], data: data, labels: labels, colors: chart[:colors])
+          = render IronAdmin::Dashboards::ChartComponent.new(title: chart[:label] || chart[:name].to_s.humanize, type: chart[:type], data: data, labels: labels, colors: chart[:colors])
 
     - if @dashboard.defined_recents.any?
       .space-y-6

--- a/lib/iron_admin/dashboard.rb
+++ b/lib/iron_admin/dashboard.rb
@@ -94,7 +94,7 @@ module IronAdmin
       # Charts display time-series or categorical data visually.
       # The block should return data in a format suitable for the chart type.
       #
-      # @param name [Symbol] The chart identifier (used as the chart title)
+      # @param name [Symbol] The chart identifier
       # @param type [Symbol] The chart type
       #   - :line - Line chart for trends over time
       #   - :bar - Bar chart for comparisons
@@ -102,22 +102,19 @@ module IronAdmin
       #   - :doughnut - Doughnut chart for proportions
       # @param colors [Array<String>, nil] Optional per-chart color palette (CSS color values).
       #   Overrides the global theme chart_colors for this chart.
+      # @param label [String, nil] Custom display title for the chart.
+      #   Defaults to `name.to_s.humanize` when not provided.
       # @yield Block that computes and returns the chart data
       # @yieldreturn [Hash, Array] Data for the chart (format depends on type)
       #
-      # @example Line chart of signups over time
-      #   chart :signups_by_month, type: :line do
-      #     User.group_by_month(:created_at).count
+      # @example Chart with custom label
+      #   chart :projects_by_status, type: :bar, label: "Projects by Status" do
+      #     Project.group(:status).count
       #   end
       #
       # @example Bar chart with custom colors
       #   chart :orders_by_status, type: :bar, colors: ["#10b981", "#3b82f6", "#ef4444"] do
       #     Order.group(:status).count
-      #   end
-      #
-      # @example Pie chart of users by role
-      #   chart :users_by_role, type: :pie do
-      #     User.group(:role).count
       #   end
       #
       # @return [void]

--- a/lib/iron_admin/dashboard.rb
+++ b/lib/iron_admin/dashboard.rb
@@ -121,8 +121,8 @@ module IronAdmin
       #   end
       #
       # @return [void]
-      def chart(name, type: :line, colors: nil, &block)
-        self.defined_charts = defined_charts + [{ name: name, type: type, colors: colors, block: block }]
+      def chart(name, type: :line, colors: nil, label: nil, &block)
+        self.defined_charts = defined_charts + [{ name: name, type: type, colors: colors, label: label, block: block }]
       end
 
       # Displays a list of recent records from a resource.

--- a/spec/lib/iron_admin/dashboard_spec.rb
+++ b/spec/lib/iron_admin/dashboard_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe IronAdmin::Dashboard do
     end
 
     it "stores label as nil when not specified" do
-      expect(TestDashboard.defined_charts.first[:label]).to be_nil
+      expect(TestDashboard.defined_charts.first).to include(label: nil)
     end
 
     it "stores label when specified" do
@@ -64,6 +64,18 @@ RSpec.describe IronAdmin::Dashboard do
 
       chart = dashboard_class.defined_charts.first
       expect(chart[:label]).to eq("Projects by Status")
+    end
+
+    it "resolves display title from label when present" do
+      chart = { name: :projects_by_status, label: "Projects by Status" }
+      title = chart[:label] || chart[:name].to_s.humanize
+      expect(title).to eq("Projects by Status")
+    end
+
+    it "resolves display title from name when label is nil" do
+      chart = { name: :projects_by_status, label: nil }
+      title = chart[:label] || chart[:name].to_s.humanize
+      expect(title).to eq("Projects by status")
     end
   end
 

--- a/spec/lib/iron_admin/dashboard_spec.rb
+++ b/spec/lib/iron_admin/dashboard_spec.rb
@@ -50,6 +50,21 @@ RSpec.describe IronAdmin::Dashboard do
     it "stores per-chart colors when specified" do
       expect(TestDashboard.defined_charts.last[:colors]).to eq(["#10b981", "#3b82f6"])
     end
+
+    it "stores label as nil when not specified" do
+      expect(TestDashboard.defined_charts.first[:label]).to be_nil
+    end
+
+    it "stores label when specified" do
+      dashboard_class = Class.new(IronAdmin::Dashboard) do
+        chart :projects_by_status, type: :bar, label: "Projects by Status" do
+          { "Draft" => 2, "Active" => 5 }
+        end
+      end
+
+      chart = dashboard_class.defined_charts.first
+      expect(chart[:label]).to eq("Projects by Status")
+    end
   end
 
   describe "recents" do


### PR DESCRIPTION
## Summary
- `Dashboard#chart` raised `ArgumentError` when `label:` was passed
- Added `label:` parameter to the chart method for custom human-readable titles
- Dashboard view uses the custom label when provided, falls back to humanized name

## Test plan
- [x] Added tests for label storage (nil when not specified, stored when specified)
- [x] All 9 dashboard specs pass
- [x] Rubocop passes with no offenses

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)