### PR TITLE
docs: align Resource.menu YARD with :group key + accept :section alias (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Tool namespace in docs** (#36) — Fixed tool examples in extending guide to use the correct `IronAdmin::Tools::` module nesting required by Zeitwerk autoloading.
 - **Policy docs** (#32) — Clarified `deny` documentation and corrected `deny` `if:` docs to receive the current user (consistent with `allow`).
 - **Custom adapter guide** — Comprehensive guide for building custom adapters: all 35 methods with signatures, return types, duck type contracts, QueryBuilder integration, testing patterns, and implementation checklist.
+- **`Resource.menu` docstring `:section` vs `:group`** (#57) — The YARD docstring on `Resource.menu` documented `@option options [String] :section`, but `ResourceRegistry#grouped` (and every existing dummy resource) keys on `:group`. The docstring now accurately documents `:group`; for backward-compat, `menu` accepts `:section` as an alias and normalizes it to `:group`.
 
 - **Nested Forms** (#23) — Inline nested form support for has_many/has_one associations:
   - `nested: true` option on `has_many` and `has_one` DSL

--- a/lib/iron_admin/resource.rb
+++ b/lib/iron_admin/resource.rb
@@ -391,13 +391,21 @@ module IronAdmin
       # @option options [String] :icon Heroicon name for the menu item
       # @option options [String] :label Custom label (defaults to pluralized model name)
       # @option options [Integer] :priority Sort order (lower = higher in menu)
-      # @option options [String] :section Group name for menu sections
+      # @option options [String] :group Group name for the sidebar section
+      #   (sibling resources sharing the same `:group` are listed together;
+      #   resources without a `:group` fall under "Resources"). `:section`
+      #   is also accepted as an alias for `:group` for backward
+      #   compatibility with earlier docs.
       #
       # @example
-      #   menu icon: "users", label: "Team Members", priority: 10
+      #   menu icon: "users", label: "Team Members", priority: 10, group: "People"
       #
       # @return [void]
       def menu(**options)
+        if options.key?(:section)
+          legacy = options.delete(:section)
+          options[:group] ||= legacy
+        end
         self.menu_options = options
       end
 

--- a/lib/iron_admin/resource.rb
+++ b/lib/iron_admin/resource.rb
@@ -404,7 +404,11 @@ module IronAdmin
       def menu(**options)
         if options.key?(:section)
           legacy = options.delete(:section)
-          options[:group] ||= legacy
+          # Preserve `:group` precedence based on key presence so that
+          # explicitly passing `group: nil` (or `group: false`) still
+          # wins over `section:`. Using `||=` would clobber falsey
+          # explicit values.
+          options[:group] = legacy unless options.key?(:group)
         end
         self.menu_options = options
       end

--- a/spec/lib/iron_admin/resource_spec.rb
+++ b/spec/lib/iron_admin/resource_spec.rb
@@ -477,6 +477,23 @@ RSpec.describe IronAdmin::Resource do
     it "stores priority in menu options" do
       expect(TestUserResource.menu_options[:priority]).to eq(0)
     end
+
+    it "accepts :section as a backward-compatible alias for :group" do
+      legacy_resource = Class.new(IronAdmin::Resource) do
+        self.model_class_override = User
+        menu icon: "key", section: "Legacy"
+      end
+      expect(legacy_resource.menu_options[:group]).to eq("Legacy")
+    end
+
+    it "prefers :group when both :group and :section are passed" do
+      mixed_resource = Class.new(IronAdmin::Resource) do
+        self.model_class_override = User
+        menu group: "Primary", section: "Legacy"
+      end
+      expect(mixed_resource.menu_options[:group]).to eq("Primary")
+      expect(mixed_resource.menu_options).not_to have_key(:section)
+    end
   end
 
   describe ".resource_policy" do

--- a/spec/lib/iron_admin/resource_spec.rb
+++ b/spec/lib/iron_admin/resource_spec.rb
@@ -494,6 +494,15 @@ RSpec.describe IronAdmin::Resource do
       expect(mixed_resource.menu_options[:group]).to eq("Primary")
       expect(mixed_resource.menu_options).not_to have_key(:section)
     end
+
+    it "respects an explicit `group: nil` over `:section` (key-presence based precedence)" do
+      explicit_nil_resource = Class.new(IronAdmin::Resource) do
+        self.model_class_override = User
+        menu group: nil, section: "Legacy"
+      end
+      expect(explicit_nil_resource.menu_options).to have_key(:group)
+      expect(explicit_nil_resource.menu_options[:group]).to be_nil
+    end
   end
 
   describe ".resource_policy" do


### PR DESCRIPTION
## Summary

- `Resource.menu` YARD docstring now documents `@option options [String] :group` (matches `ResourceRegistry#grouped` and every dummy resource).
- `menu` accepts `:section` as a backward-compat alias and normalizes it to `:group` so existing code following the old docstring keeps working.
- `:group` wins when both are passed.

Closes #57.

## Why

The docstring claimed `:section` but the registry has always read `:group`. Users following the documented API silently got their resources placed under the default "Resources" group.

## Test plan

- [x] `bundle exec rspec spec/lib/iron_admin/resource_spec.rb -e "menu"` → 4 examples, 0 failures (2 new tests: alias normalization and `:group` precedence)
- [x] `bundle exec rspec spec/` → 1851 examples, 0 failures
- [x] `bundle exec rubocop` → no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)