### PR TITLE
fix: also link chart.min.js in iron_admin_manifest.js

### DIFF
--- a/app/assets/config/iron_admin_manifest.js
+++ b/app/assets/config/iron_admin_manifest.js
@@ -1,1 +1,12 @@
+// Sprockets manifest for IronAdmin engine assets.
+// Engine initializer adds this manifest to the host's precompile list,
+// recursively pulling these assets into Sprockets' precompile set.
+
+// Stimulus / importmap entry point + controllers.
 //= link_tree ../../javascript/iron_admin .js
+
+// Chart.js (vendored) — loaded by the dashboard layout via
+// `javascript_include_tag "chart.min"`. Without this link, hosts on
+// sprockets-rails 500 on `/admin` with
+// `Asset 'chart.min.js' was not declared to be precompiled`.
+//= link chart.min.js


### PR DESCRIPTION
## Summary

Follow-up to #66. Adds `//= link chart.min.js` to the engine manifest so the vendored Chart.js asset is part of the sprockets precompile set.

## Why

#66 fixed the missing `iron_admin_manifest.js` and pulled in `app/javascript/iron_admin/**/*.js`, but the dashboard layout also includes `chart.min.js` via:

```haml
= javascript_include_tag "chart.min", defer: true, ...
```

The asset lives in `vendor/assets/javascripts/`. Without an explicit `link` directive it stayed off the precompile list, so hosts on sprockets-rails got a fresh 500 on `/admin`:

```
Asset `chart.min.js` was not declared to be precompiled in production.
```

## Test plan

- [x] `bundle exec rspec spec/` → 1861 examples, 0 failures
- [x] `bundle exec rubocop` → no offenses
- [x] Manually verified in `examples/mysql_app` (Rails 7.1 + sprockets-rails): `/admin` now returns 200 (previously 500 even after #66 landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)