### PR TITLE
fix: invalidate stale @adapter when adapter_class changes (#62 follow-up)

### DIFF
--- a/lib/iron_admin/resource.rb
+++ b/lib/iron_admin/resource.rb
@@ -82,9 +82,17 @@ module IronAdmin
       # query building, and CRUD operations regardless of the underlying
       # data source (ActiveRecord, Mongoid, HTTP, etc.).
       #
+      # Defensively re-resolves when the cached `@adapter` doesn't match
+      # the currently configured `adapter_class`. This catches the case
+      # where the eager `Resource.inherited` flow memoized an
+      # `Adapters::ActiveRecord` built before the subclass body's
+      # `self.adapter_class = :mongoid` (or `:http`) took effect.
+      #
       # @return [IronAdmin::Adapters::Base] The adapter instance
       def adapter
-        @adapter ||= resolve_adapter_class.new(model)
+        wanted = resolve_adapter_class
+        @adapter = nil if @adapter && !@adapter.instance_of?(wanted)
+        @adapter ||= wanted.new(model)
       end
 
       # Returns the ActiveRecord model class for this resource.

--- a/lib/iron_admin/resource_registry.rb
+++ b/lib/iron_admin/resource_registry.rb
@@ -65,9 +65,20 @@ module IronAdmin
       # and swallowed per resource so a single broken resource (missing
       # model class, unreachable DB, etc.) doesn't take down the boot.
       #
+      # The cached `@adapter` instance is invalidated for every resource
+      # before re-running registration. The eager `Resource.adapter` call
+      # at inheritance time memoized an `Adapters::ActiveRecord.new(model)`
+      # — built with whatever `adapter_class` defaulted to before the
+      # class body's `self.adapter_class = :mongoid` (or `:http`) had
+      # taken effect. Without this invalidation, every subsequent
+      # `Resource.adapter` would keep returning that stale AR adapter
+      # and Mongoid/HTTP resources would 500 with `undefined method
+      # 'columns' for <MongoidModel>`.
+      #
       # @return [void]
       def finalize!
         all.each do |resource_class|
+          resource_class.instance_variable_set(:@adapter, nil)
           resource_class.register_soft_delete_features
         rescue StandardError => e
           warn_finalize_failure(resource_class, e)

--- a/spec/lib/iron_admin/resource_registry_spec.rb
+++ b/spec/lib/iron_admin/resource_registry_spec.rb
@@ -141,5 +141,15 @@ RSpec.describe IronAdmin::ResourceRegistry do
         .with(/Could not finalize ResourceA.*NoMethodError.*boom/)
       expect(resource_b).to have_received(:register_soft_delete_features)
     end
+
+    it "invalidates each resource's memoized @adapter" do
+      # Force memoization with a stale adapter, then verify finalize!
+      # clears it so the next access re-resolves.
+      resource_a.instance_variable_set(:@adapter, :stale_adapter_marker)
+
+      described_class.finalize!
+
+      expect(resource_a.instance_variable_get(:@adapter)).not_to eq(:stale_adapter_marker)
+    end
   end
 end

--- a/spec/lib/iron_admin/resource_spec.rb
+++ b/spec/lib/iron_admin/resource_spec.rb
@@ -28,6 +28,30 @@ RSpec.describe IronAdmin::Resource do
       adapter2 = TestUserResource.adapter
       expect(adapter1).to equal(adapter2)
     end
+
+    it "re-resolves when adapter_class changes after the first call" do
+      # Simulates the boot path where `Resource.inherited` memoizes an
+      # ActiveRecord adapter before the subclass body sets
+      # `self.adapter_class = :mongoid` (or similar). The next access
+      # must produce a fresh adapter that matches the configured class.
+      resource = Class.new(IronAdmin::Resource) do
+        self.model_class_override = User
+
+        def self.name
+          "AdapterRebindResource"
+        end
+      end
+
+      first = resource.adapter
+      expect(first).to be_a(IronAdmin::Adapters::ActiveRecord)
+
+      stub_adapter = Class.new(IronAdmin::Adapters::Base)
+      resource.adapter_class = stub_adapter
+
+      second = resource.adapter
+      expect(second).to be_a(stub_adapter)
+      expect(second).not_to equal(first)
+    end
   end
 
   describe ".adapter_class" do


### PR DESCRIPTION
## Summary

Follow-up to #68. Mongoid and HTTP resources now actually use the right adapter at request time.

- `ResourceRegistry.finalize!` invalidates each resource's memoized `@adapter` before re-running `register_soft_delete_features`.
- `Resource.adapter` defensively re-resolves when the memoized instance no longer matches the configured `adapter_class`.

## Why

#68 made non-AR resources register, but they still 500'd at request time:

```
NoMethodError (undefined method `columns' for User:Class):
  lib/iron_admin/adapters/active_record.rb:13:in `columns'
  lib/iron_admin/resource.rb:730:in `infer_column_filters'
```

Root cause: the eager `Resource.inherited` flow called `Resource.adapter`, which memoized `IronAdmin::Adapters::ActiveRecord.new(MongoidUser)` because `adapter_class` was still the parent default (`:active_record`) at inheritance time. The class body's `self.adapter_class = :mongoid` set the symbol but the `@adapter` instance was already cached, so every later access kept returning the AR adapter wrapping a Mongoid model — boom on `.columns`.

`instance_of?` is used (not `is_a?`) so a memoized `Adapters::ActiveRecord` doesn't satisfy a `:mongoid` request via the shared `Adapters::Base` ancestor.

## Test plan

- [x] `bundle exec rspec spec/` → 1863 examples, 0 failures (2 new tests: re-resolve after `adapter_class=` rebind, `finalize!` invalidates `@adapter`)
- [x] `bundle exec rubocop` → no offenses
- [x] Manually verified in `examples/mongo_app`: registry has 5 Mongoid resources, request-path no longer 500s on the AR `.columns` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)