### PR TITLE
fix: Mongoid 9 compat — derive macro from association class name

### DIFF
--- a/lib/iron_admin/adapters/mongoid/association_wrapper.rb
+++ b/lib/iron_admin/adapters/mongoid/association_wrapper.rb
@@ -25,8 +25,27 @@ module IronAdmin
         def initialize(relation)
           @relation = relation
           @name = relation.name.to_sym
-          @macro = MACRO_MAP.fetch(relation.macro, relation.macro)
+          @macro = MACRO_MAP.fetch(raw_macro_for(relation), raw_macro_for(relation))
         end
+
+        private
+
+        # Mongoid 9 dropped `Association#macro`. Derive the macro symbol
+        # from the association class name instead, e.g.
+        # `Mongoid::Association::Referenced::BelongsTo` → :belongs_to,
+        # `Mongoid::Association::Embedded::EmbedsMany` → :embeds_many.
+        # Falls back to `relation.macro` when defined (Mongoid <= 8).
+        #
+        # @param relation [Object] A Mongoid association metadata instance
+        # @return [Symbol] The macro symbol (e.g. :belongs_to, :has_many,
+        #   :embeds_many, :embedded_in)
+        def raw_macro_for(relation)
+          return relation.macro if relation.respond_to?(:macro)
+
+          relation.class.name.split("::").last.underscore.to_sym
+        end
+
+        public
 
         def klass
           @relation.class_name.constantize

--- a/spec/lib/iron_admin/adapters/mongoid/association_wrapper_spec.rb
+++ b/spec/lib/iron_admin/adapters/mongoid/association_wrapper_spec.rb
@@ -88,6 +88,49 @@ RSpec.describe IronAdmin::Adapters::Mongoid::AssociationWrapper do
         expect(wrapper.macro).to eq(:has_and_belongs_to_many)
       end
     end
+
+    context "when the relation does not respond to :macro (Mongoid 9+)" do
+      # In Mongoid 9, association metadata classes (e.g.
+      # `Mongoid::Association::Referenced::BelongsTo`) no longer expose
+      # `#macro`. The wrapper has to derive the macro from the class
+      # name instead.
+      let(:relation) do
+        klass = Class.new do
+          def self.name
+            "Mongoid::Association::Referenced::BelongsTo"
+          end
+
+          def name = "parent"
+          def class_name = "Parent"
+          def foreign_key = "parent_id"
+          def polymorphic? = false
+        end
+        klass.new
+      end
+
+      it "derives the macro from the relation's class name" do
+        expect(wrapper.macro).to eq(:belongs_to)
+      end
+    end
+
+    context "when an embedded relation does not respond to :macro (Mongoid 9+)" do
+      let(:relation) do
+        klass = Class.new do
+          def self.name
+            "Mongoid::Association::Embedded::EmbedsMany"
+          end
+
+          def name = "comments"
+          def class_name = "Comment"
+          def polymorphic? = false
+        end
+        klass.new
+      end
+
+      it "still normalizes derived `:embeds_many` to `:has_many`" do
+        expect(wrapper.macro).to eq(:has_many)
+      end
+    end
   end
 
   describe "#klass" do


### PR DESCRIPTION
## Summary

`AssociationWrapper` called `relation.macro` to map embedded macros to their IronAdmin equivalents. Mongoid 9 removed `Association#macro`, so every Mongoid resource that exposes any `belongs_to`/`has_many`/`embeds_many` etc. 500'd on its index/show/edit pages.

The wrapper now derives the macro symbol from the association class name (`Mongoid::Association::Referenced::BelongsTo` → `:belongs_to`, `Mongoid::Association::Embedded::EmbedsMany` → `:embeds_many`, …) and falls back to `relation.macro` when defined for Mongoid ≤ 8 hosts.

## Why

Reproduction in `examples/mongo_app` (Mongoid 9):

```
NoMethodError (undefined method `macro' for
 #<Mongoid::Association::Referenced::BelongsTo @owner_class=Category, @name=:parent ...>):
  lib/iron_admin/adapters/mongoid/association_wrapper.rb:28:in `initialize'
  lib/iron_admin/adapters/mongoid.rb:53:in `block in associations'
```

`relation.respond_to?(:macro)` is `false` in Mongoid 9; the class-name parse is the supported path going forward.

## Test plan

- [x] `bundle exec rspec spec/lib/iron_admin/adapters/mongoid/association_wrapper_spec.rb` → 15 examples, 0 failures (2 new tests for the Mongoid 9+ path: derived `:belongs_to` and derived `:embeds_many` normalized to `:has_many`)
- [x] `bundle exec rspec spec/` → 1865 examples, 0 failures
- [x] `bundle exec rubocop` → no offenses
- [x] Manually verified in `examples/mongo_app` (Mongoid 9): resources with `belongs_to :parent` (Category) and `embeds_many :comments` (Article) no longer 500 on the missing `.macro` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)