### PR TITLE
fix: form view also uses display_record_label for belongs_to (#63 follow-up)

### DIFF
--- a/app/views/iron_admin/resources/_form.html.haml
+++ b/app/views/iron_admin/resources/_form.html.haml
@@ -18,8 +18,9 @@
           - assoc_class = field.options[:association_class]
           - fk = field.options[:foreign_key]
           - display_method = field.options[:display]
+          - belongs_to_options = assoc_class.all.map { |r| [display_record_label(r, display_method), r.id] }
           = f.select fk,
-            options_from_collection_for_select(assoc_class.all, :id, (display_method || :name), @record.public_send(fk)),
+            options_for_select(belongs_to_options, @record.public_send(fk)),
             { include_blank: I18n.t("iron_admin.fields.select_placeholder") },
             class: [cp_select_class, (error_input_class if has_error)].compact.join(" ")
         - when :text


### PR DESCRIPTION
## Summary

Follow-up to #70. The inline `app/views/iron_admin/resources/_form.html.haml` was a separate code path from `BelongsToComponent` and still hard-coded `:name` for the belongs_to select label. Now it routes through the `display_record_label` helper that already powers index/show pages.

Closes the remaining `undefined method 'name' for an instance of <Model>` 500 on new/edit forms when the associated model has no `:name`.

## Why

PR #70 fixed `BelongsToComponent`'s `option_label_for`, but the form view doesn't go through that component. It calls `options_from_collection_for_select(assoc_class.all, :id, :name, ...)` directly. So:

- `Invoice belongs_to :subscription` (Subscription has no `:name` column) → 500 on `/admin/invoices/new`.

This commit replaces the line with an explicit `assoc_class.all.map { |r| [display_record_label(r, display_method), r.id] }` so the same fallback chain (`:name` → `:title` → `:email` → `:label` → `:slug` → `Model #id`) applies.

## Test plan

- [x] `bundle exec rspec spec/` → 1861 examples, 0 failures
- [x] `bundle exec rubocop` → no offenses
- [x] Manually verified in `examples/hybrid_app` (Rails 8 + Mongoid + AR + HTTP): `/admin/invoices/new` renders 200 (was 500 with `undefined method 'name' for an instance of Subscription`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)