### PR TITLE
[codex] Add polling live updates (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dashboard metric icons** (#34) — `metric` DSL now accepts `icon:` keyword for Heroicon display alongside metric values.
 - **Dashboard chart labels** (#35) — `chart` DSL now accepts `label:` keyword for custom display titles, falling back to `name.to_s.humanize`.
 - **CSV/JSON imports** (#53) — Resources can opt in to uploads with `imports :csv, :json`, constrain importable fields, configure upsert keys, preview mapped rows, and create/update records through adapter-driven persistence.
+- **Polling live updates** (#54) — Added opt-in `live_updates = :polling`, a thread-safe poll cache, Turbo Stream broadcaster, live polling endpoint, dashboard `live:` options, and stable resource/metric DOM targets.
 
 ### Fixed
 

--- a/app/components/iron_admin/dashboards/metric_card_component.html.haml
+++ b/app/components/iron_admin/dashboards/metric_card_component.html.haml
@@ -1,4 +1,4 @@
-.bg-white.rounded-lg.shadow.p-6
+.bg-white.rounded-lg.shadow.p-6{ id: (live_target_id if live?) }
   .flex.items-center.justify-between
     %div
       %p.text-sm.font-medium.text-gray-500= label

--- a/app/components/iron_admin/dashboards/metric_card_component.rb
+++ b/app/components/iron_admin/dashboards/metric_card_component.rb
@@ -8,11 +8,13 @@ module IronAdmin
       # @param value [Numeric] Metric value
       # @param format [Symbol] Format (:number, :currency, :percentage)
       # @param icon [String, nil] Optional Heroicon name (e.g., "users", "currency-dollar")
-      def initialize(name:, value:, format: :number, icon: nil)
+      # @param live [Boolean] Whether to render a stable Turbo Stream target id
+      def initialize(name:, value:, format: :number, icon: nil, live: false)
         @name = name
         @value = value
         @format = format
         @icon = icon
+        @live = live
       end
 
       # @api private
@@ -29,6 +31,18 @@ module IronAdmin
       # @return [String] Humanized metric label
       def label
         @name.to_s.humanize
+      end
+
+      # @api private
+      # @return [Boolean] True when the metric should expose a live target
+      def live?
+        @live
+      end
+
+      # @api private
+      # @return [String] Stable Turbo Stream target id
+      def live_target_id
+        "metric_#{@name.to_s.parameterize(separator: "_")}"
       end
 
       # @api private

--- a/app/components/iron_admin/resources/data_table_component.html.haml
+++ b/app/components/iron_admin/resources/data_table_component.html.haml
@@ -23,7 +23,7 @@
             No records found.
     - else
       - records.each do |record|
-        %tr{ class: theme.table_row_hover }
+        %tr{ id: row_dom_id(record), class: theme.table_row_hover }
           - visible_fields.each do |field|
             %td.px-6.py-4.whitespace-nowrap.text-sm{ class: theme.body_text }
               = helpers.display_index_field_value(record, field)

--- a/app/components/iron_admin/resources/data_table_component.rb
+++ b/app/components/iron_admin/resources/data_table_component.rb
@@ -89,6 +89,12 @@ module IronAdmin
       def sort_direction
         current_direction
       end
+
+      # @api private
+      # @return [String] Stable Turbo Stream target id for a record row
+      def row_dom_id(record)
+        "iron_admin_#{resource_class.resource_name}_row_#{record.id}"
+      end
     end
   end
 end

--- a/app/controllers/iron_admin/live_controller.rb
+++ b/app/controllers/iron_admin/live_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module IronAdmin
+  class LiveController < ApplicationController
+    def show
+      return head(:not_found) unless IronAdmin::Live.polling?
+
+      render plain: IronAdmin::Live.poll_cache.fetch(params[:stream]).join,
+             content_type: Mime[:turbo_stream]
+    end
+  end
+end

--- a/app/views/iron_admin/dashboard/index.html.haml
+++ b/app/views/iron_admin/dashboard/index.html.haml
@@ -5,7 +5,7 @@
     - if @dashboard.defined_metrics.any?
       .grid.grid-cols-1.md:grid-cols-2.lg:grid-cols-4.gap-6.mb-8
         - @dashboard.defined_metrics.each do |metric|
-          = render IronAdmin::Dashboards::MetricCardComponent.new(name: metric[:name], value: metric[:block].call, format: metric[:format], icon: metric[:icon])
+          = render IronAdmin::Dashboards::MetricCardComponent.new(name: metric[:name], value: metric[:block].call, format: metric[:format], icon: metric[:icon], live: metric[:live])
 
     - if @dashboard.defined_charts.any?
       = javascript_include_tag "chart.min", defer: true, onload: "document.dispatchEvent(new CustomEvent('chartjs:loaded'))"
@@ -14,7 +14,12 @@
           - chart_data = chart[:block].call
           - labels = chart_data.keys
           - data = chart_data.values
-          = render IronAdmin::Dashboards::ChartComponent.new(title: chart[:label] || chart[:name].to_s.humanize, type: chart[:type], data: data, labels: labels, colors: chart[:colors])
+          - chart_title = chart[:label] || chart[:name].to_s.humanize
+          - if chart[:live]
+            %div{ id: "chart_#{chart[:name].to_s.parameterize(separator: "_")}" }
+              = render IronAdmin::Dashboards::ChartComponent.new(title: chart_title, type: chart[:type], data: data, labels: labels, colors: chart[:colors])
+          - else
+            = render IronAdmin::Dashboards::ChartComponent.new(title: chart_title, type: chart[:type], data: data, labels: labels, colors: chart[:colors])
 
     - if @dashboard.defined_recents.any?
       .space-y-6

--- a/app/views/iron_admin/resources/index.html.haml
+++ b/app/views/iron_admin/resources/index.html.haml
@@ -163,7 +163,7 @@
                 %td.px-6.py-8.text-center.text-sm{ colspan: (@fields.count { |f| f.visible?(iron_admin_current_user) }) + (has_bulk_actions ? 2 : 1), class: cp_muted_text }
                   = I18n.t("iron_admin.resources.index.empty_state")
             - @records.each do |record|
-              %tr{ class: cp_table_row_hover }
+              %tr{ id: ("iron_admin_#{@resource_class.resource_name}_row_#{record.id}" if @resource_class.live_index_enabled?), class: cp_table_row_hover }
                 - if has_bulk_actions
                   %td.px-6.py-4.w-4
                     %input{ type: "checkbox", name: "ids[]", value: record.id, class: "rounded border-gray-300",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ IronAdmin::Engine.routes.draw do
 
   get "search", to: "search#index", as: :search
   get "audit", to: "audit#index", as: :audit
+  get "live/:stream", to: "live#show", as: :live
   get "autocomplete/:resource_name", to: "resources#autocomplete", as: :autocomplete
   get ":resource_name/export", to: "exports#show", as: :export
   get ":resource_name/import", to: "imports#new", as: :resource_import

--- a/lib/iron_admin.rb
+++ b/lib/iron_admin.rb
@@ -3,6 +3,9 @@
 require "iron_admin/version"
 require "iron_admin/errors"
 require "iron_admin/configuration"
+require "iron_admin/live/poll_cache"
+require "iron_admin/live/broadcaster"
+require "iron_admin/live"
 require "iron_admin/adapters/base"
 require "iron_admin/adapters/registry"
 require "iron_admin/adapters/active_record"
@@ -17,6 +20,7 @@ require "iron_admin/nested_attributes_validator"
 require "iron_admin/concerns/nestable"
 require "iron_admin/concerns/soft_deletable"
 require "iron_admin/concerns/importable"
+require "iron_admin/concerns/live_updatable"
 require "iron_admin/filters/base_query_builder"
 require "iron_admin/filters/active_record_query_builder"
 require "iron_admin/filters/query_builder"
@@ -145,6 +149,7 @@ module IronAdmin
     def reset_configuration!
       @configuration = Configuration.new
       @dashboard_class = nil
+      Live.reset! if defined?(Live)
     end
 
     def register_field_type(type_name, &)

--- a/lib/iron_admin/concerns/live_updatable.rb
+++ b/lib/iron_admin/concerns/live_updatable.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module IronAdmin
+  module Concerns
+    module LiveUpdatable
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :live_index_enabled, default: false
+        class_attribute :live_show_enabled, default: false
+      end
+
+      class_methods do
+        def live_index(value = nil, enabled: true)
+          self.live_index_enabled = value.nil? ? enabled : value
+        end
+
+        def live_show(value = nil, enabled: true)
+          self.live_show_enabled = value.nil? ? enabled : value
+        end
+
+        def live_index_enabled?
+          !!live_index_enabled
+        end
+
+        def live_show_enabled?
+          !!live_show_enabled
+        end
+
+        def live_stream_name(scope, record_id = nil)
+          parts = ["resources", resource_name, scope]
+          parts << record_id if record_id
+          parts.join(":")
+        end
+      end
+    end
+  end
+end

--- a/lib/iron_admin/configuration.rb
+++ b/lib/iron_admin/configuration.rb
@@ -87,6 +87,15 @@ module IronAdmin
     # @return [Hash] Default headers for HTTP adapter (e.g., auth tokens)
     attr_accessor :http_headers
 
+    # @return [Symbol] Live update strategy (:disabled or :polling)
+    attr_accessor :live_updates
+
+    # @return [ActiveSupport::Duration] Client polling interval for live updates
+    attr_accessor :live_poll_interval
+
+    # @return [ActiveSupport::Duration] Minimum interval between live broadcasts
+    attr_accessor :live_throttle
+
     # @return [Proc, nil] Authentication block
     # @see #authenticate
     attr_reader :authenticate_block
@@ -179,6 +188,9 @@ module IronAdmin
       @sticky_actions_column = true
       @http_base_url = nil
       @http_headers = {}
+      @live_updates = :disabled
+      @live_poll_interval = 3.seconds
+      @live_throttle = 0.5.seconds
     end
 
     # Defines the authentication check for admin access.

--- a/lib/iron_admin/dashboard.rb
+++ b/lib/iron_admin/dashboard.rb
@@ -81,8 +81,8 @@ module IronAdmin
       #   end
       #
       # @return [void]
-      def metric(name, format: :number, icon: nil, &block)
-        self.defined_metrics = defined_metrics + [{ name: name, format: format, icon: icon, block: block }]
+      def metric(name, format: :number, icon: nil, live: false, &block)
+        self.defined_metrics = defined_metrics + [{ name: name, format: format, icon: icon, live: live, block: block }]
       end
 
       # Defines a chart for the dashboard.
@@ -114,8 +114,10 @@ module IronAdmin
       #   end
       #
       # @return [void]
-      def chart(name, type: :line, colors: nil, label: nil, &block)
-        self.defined_charts = defined_charts + [{ name: name, type: type, colors: colors, label: label, block: block }]
+      def chart(name, type: :line, colors: nil, label: nil, live: false, &block)
+        self.defined_charts = defined_charts + [
+          { name: name, type: type, colors: colors, label: label, live: live, block: block },
+        ]
       end
 
       # Displays a list of recent records from a resource.

--- a/lib/iron_admin/live.rb
+++ b/lib/iron_admin/live.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module IronAdmin
+  module Live
+    class << self
+      attr_writer :poll_cache
+
+      def enabled?
+        IronAdmin.configuration.live_updates != :disabled
+      end
+
+      def polling?
+        IronAdmin.configuration.live_updates == :polling
+      end
+
+      def poll_cache
+        @poll_cache ||= PollCache.new
+      end
+
+      def broadcaster
+        Broadcaster.new(cache: poll_cache)
+      end
+
+      def reset!
+        @poll_cache = PollCache.new
+      end
+    end
+  end
+end

--- a/lib/iron_admin/live/broadcaster.rb
+++ b/lib/iron_admin/live/broadcaster.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "erb"
+
+module IronAdmin
+  module Live
+    class Broadcaster
+      def initialize(cache: IronAdmin::Live.poll_cache)
+        @cache = cache
+      end
+
+      def broadcast_replace(stream, target:, html:)
+        broadcast_action(stream, action: :replace, target: target, html: html)
+      end
+
+      def broadcast_prepend(stream, target:, html:)
+        broadcast_action(stream, action: :prepend, target: target, html: html)
+      end
+
+      def broadcast_remove(stream, target:)
+        broadcast_action(stream, action: :remove, target: target)
+      end
+
+      private
+
+      def broadcast_action(stream, action:, target:, html: nil)
+        @cache.push(stream, turbo_stream(action: action, target: target, html: html))
+      end
+
+      def turbo_stream(action:, target:, html: nil)
+        action_attr = escape(action)
+        target_attr = escape(target)
+        return %(<turbo-stream action="#{action_attr}" target="#{target_attr}"></turbo-stream>) if html.nil?
+
+        %(<turbo-stream action="#{action_attr}" target="#{target_attr}"><template>#{html}</template></turbo-stream>)
+      end
+
+      def escape(value)
+        ERB::Util.html_escape(value.to_s)
+      end
+    end
+  end
+end

--- a/lib/iron_admin/live/poll_cache.rb
+++ b/lib/iron_admin/live/poll_cache.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module IronAdmin
+  module Live
+    class PollCache
+      def initialize
+        @mutex = Mutex.new
+        @streams = Hash.new { |hash, key| hash[key] = [] }
+      end
+
+      def push(stream, payload)
+        @mutex.synchronize do
+          @streams[stream.to_s] << payload.to_s
+        end
+      end
+
+      def fetch(stream)
+        @mutex.synchronize do
+          @streams.delete(stream.to_s) || []
+        end
+      end
+
+      def clear!
+        @mutex.synchronize { @streams.clear }
+      end
+    end
+  end
+end

--- a/lib/iron_admin/resource.rb
+++ b/lib/iron_admin/resource.rb
@@ -43,6 +43,7 @@ module IronAdmin
     include Concerns::Nestable
     include Concerns::SoftDeletable
     include Concerns::Importable
+    include Concerns::LiveUpdatable
 
     class_attribute :field_overrides, default: {}
     class_attribute :_searchable_columns, default: nil

--- a/spec/components/iron_admin/dashboards/metric_card_component_spec.rb
+++ b/spec/components/iron_admin/dashboards/metric_card_component_spec.rb
@@ -30,4 +30,10 @@ RSpec.describe IronAdmin::Dashboards::MetricCardComponent, type: :component do
 
     expect(result.css("svg").size).to eq(1)
   end
+
+  it "adds a stable target id when live rendering is enabled" do
+    result = render_inline(described_class.new(name: :total_users, value: 42, format: :number, live: true))
+
+    expect(result.css("#metric_total_users").size).to eq(1)
+  end
 end

--- a/spec/components/iron_admin/resources/data_table_component_spec.rb
+++ b/spec/components/iron_admin/resources/data_table_component_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe IronAdmin::Resources::DataTableComponent, type: :component do
     end
   end
 
+  describe "#row_dom_id" do
+    it "returns stable row ids for live replacement targets" do
+      user = users.first
+      component = described_class.new(
+        records: users,
+        fields: fields,
+        resource_class: IronAdmin::Resources::UserResource,
+        base_url: "/admin/users?"
+      )
+
+      expect(component.row_dom_id(user)).to eq("iron_admin_users_row_#{user.id}")
+    end
+  end
+
   describe "#empty?" do
     it "returns true when records are empty" do
       component = described_class.new(

--- a/spec/lib/iron_admin/configuration_spec.rb
+++ b/spec/lib/iron_admin/configuration_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe IronAdmin::Configuration do
     it "sets sticky_actions_column to true" do
       expect(config.sticky_actions_column).to be true
     end
+
+    it "disables live updates by default" do
+      expect(config.live_updates).to eq(:disabled)
+    end
+
+    it "sets default live polling settings" do
+      expect(config.live_poll_interval).to eq(3.seconds)
+      expect(config.live_throttle).to eq(0.5.seconds)
+    end
   end
 
   describe "#badge_colors" do
@@ -232,6 +241,16 @@ RSpec.describe IronAdmin::Configuration do
       config.sticky_actions_column = false
 
       expect(config.sticky_actions_column).to be false
+    end
+
+    it "allows setting live update options" do
+      config.live_updates = :polling
+      config.live_poll_interval = 10.seconds
+      config.live_throttle = 2.seconds
+
+      expect(config.live_updates).to eq(:polling)
+      expect(config.live_poll_interval).to eq(10.seconds)
+      expect(config.live_throttle).to eq(2.seconds)
     end
   end
 end

--- a/spec/lib/iron_admin/dashboard_spec.rb
+++ b/spec/lib/iron_admin/dashboard_spec.rb
@@ -51,6 +51,17 @@ RSpec.describe IronAdmin::Dashboard do
       metric = dashboard_class.defined_metrics.first
       expect(metric[:icon]).to eq("users")
     end
+
+    it "stores live option when specified" do
+      dashboard_class = Class.new(IronAdmin::Dashboard) do
+        metric :active_users, live: true do
+          10
+        end
+      end
+
+      metric = dashboard_class.defined_metrics.first
+      expect(metric[:live]).to be true
+    end
   end
 
   describe "charts" do
@@ -80,6 +91,17 @@ RSpec.describe IronAdmin::Dashboard do
 
       chart = dashboard_class.defined_charts.first
       expect(chart[:label]).to eq("Projects by Status")
+    end
+
+    it "stores live option when specified" do
+      dashboard_class = Class.new(IronAdmin::Dashboard) do
+        chart :projects_by_status, type: :bar, live: true do
+          { "Draft" => 2, "Active" => 5 }
+        end
+      end
+
+      chart = dashboard_class.defined_charts.first
+      expect(chart[:live]).to be true
     end
 
     it "resolves display title from label when present" do

--- a/spec/lib/iron_admin/live/broadcaster_spec.rb
+++ b/spec/lib/iron_admin/live/broadcaster_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IronAdmin::Live::Broadcaster do
+  it "stores replace actions as Turbo Stream markup in the poll cache" do
+    cache = IronAdmin::Live::PollCache.new
+    broadcaster = described_class.new(cache: cache)
+
+    broadcaster.broadcast_replace("dashboard", target: "metric_total_users", html: "<div>42</div>")
+
+    body = cache.fetch("dashboard").join
+    expect(body).to include(%(action="replace"))
+    expect(body).to include(%(target="metric_total_users"))
+    expect(body).to include("<div>42</div>")
+  end
+
+  it "stores remove actions without a template" do
+    cache = IronAdmin::Live::PollCache.new
+    broadcaster = described_class.new(cache: cache)
+
+    broadcaster.broadcast_remove("users:index", target: "iron_admin_users_row_1")
+
+    body = cache.fetch("users:index").join
+    expect(body).to include(%(action="remove"))
+    expect(body).to include(%(target="iron_admin_users_row_1"))
+    expect(body).not_to include("<template>")
+  end
+end

--- a/spec/lib/iron_admin/live/poll_cache_spec.rb
+++ b/spec/lib/iron_admin/live/poll_cache_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IronAdmin::Live::PollCache do
+  it "stores and drains updates by stream name" do
+    cache = described_class.new
+
+    cache.push("dashboard", "<turbo-stream>one</turbo-stream>")
+    cache.push("dashboard", "<turbo-stream>two</turbo-stream>")
+
+    expect(cache.fetch("dashboard")).to eq(["<turbo-stream>one</turbo-stream>", "<turbo-stream>two</turbo-stream>"])
+    expect(cache.fetch("dashboard")).to eq([])
+  end
+
+  it "keeps streams isolated" do
+    cache = described_class.new
+
+    cache.push("dashboard", "dashboard-update")
+    cache.push("users:index", "users-update")
+
+    expect(cache.fetch("dashboard")).to eq(["dashboard-update"])
+    expect(cache.fetch("users:index")).to eq(["users-update"])
+  end
+end

--- a/spec/lib/iron_admin/resource_spec.rb
+++ b/spec/lib/iron_admin/resource_spec.rb
@@ -73,6 +73,31 @@ RSpec.describe IronAdmin::Resource do
     end
   end
 
+  describe "live update DSL" do
+    it "keeps live index and show disabled by default" do
+      expect(TestUserResource.live_index_enabled?).to be false
+      expect(TestUserResource.live_show_enabled?).to be false
+    end
+
+    it "stores live index and show settings" do
+      resource = Class.new(IronAdmin::Resource) do
+        self.model_class_override = User
+
+        def self.name
+          "LiveUserResource"
+        end
+
+        live_index true
+        live_show true
+      end
+
+      expect(resource.live_index_enabled?).to be true
+      expect(resource.live_show_enabled?).to be true
+      expect(resource.live_stream_name(:index)).to eq("resources:users:index")
+      expect(resource.live_stream_name(:show, 42)).to eq("resources:users:show:42")
+    end
+  end
+
   describe "field overrides" do
     it "merges overrides with inferred fields" do
       fields = TestLicenseResource.resolved_fields

--- a/spec/requests/iron_admin/live_spec.rb
+++ b/spec/requests/iron_admin/live_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "IronAdmin::Live", type: :request do
+  it "returns not found while live updates are disabled" do
+    get iron_admin.live_path("dashboard"), headers: turbo_stream_headers
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "returns and drains pending Turbo Stream updates when polling is enabled" do
+    IronAdmin.configuration.live_updates = :polling
+    IronAdmin::Live.poll_cache.push("dashboard", %(<turbo-stream action="replace" target="metric_total_users"><template>42</template></turbo-stream>))
+
+    get iron_admin.live_path("dashboard"), headers: turbo_stream_headers
+
+    expect(response).to have_http_status(:ok)
+    expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+    expect(response.body).to include(%(target="metric_total_users"))
+
+    get iron_admin.live_path("dashboard"), headers: turbo_stream_headers
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq("")
+  end
+
+  def turbo_stream_headers
+    { "ACCEPT" => "text/vnd.turbo-stream.html" }
+  end
+end


### PR DESCRIPTION
## Summary
- Adds polling endpoints and live update configuration for resources and dashboards.
- Adds live wrappers for dashboard metrics/charts and stable resource row identifiers.
- Adds live cache/broadcaster unit coverage plus request/component specs.

Closes #54

## Validation
- bundle exec rspec --format progress
- bundle exec rubocop
- git diff --check