### PR TITLE
Fix controller hardening edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Controller hardening for malformed params and missing records** (#98) — Resource show/edit/update/destroy now return 404 for missing or inaccessible records instead of surfacing `IronAdmin::RecordNotFound`; malformed array-shaped `record` params now return 400; array-shaped numeric filter params no longer crash the index view; composite-primary-key autocomplete now searches a real text column fallback and returns `to_param` ids.
 - **Nested association JSON fields** (#86) — Nested forms now render `:json` child fields as pretty-printed textareas and coerce both `has_many`-style and `has_one`-style nested `*_attributes` JSON strings back into structured values.
 - **Polymorphic type inference in lazy-loaded ActiveRecord apps** (#84) — Polymorphic inverse discovery moved behind adapter hooks and ActiveRecord eager-loads model paths before scanning descendants.
 - **Mongoid polymorphic type inference** (#85) — Mongoid resources now discover loaded document classes that declare matching polymorphic inverse relations through the adapter hook.

--- a/app/controllers/iron_admin/application_controller.rb
+++ b/app/controllers/iron_admin/application_controller.rb
@@ -13,7 +13,10 @@ module IronAdmin
 
     before_action :authenticate_iron_admin_user!
 
-    helper_method :iron_admin_current_user
+    rescue_from IronAdmin::RecordNotFound, with: :render_not_found
+    rescue_from ActionController::ParameterMissing, with: :render_bad_request
+
+    helper_method :iron_admin_current_user, :iron_admin_filter_param, :iron_admin_active_filter?
 
     private
 
@@ -29,6 +32,34 @@ module IronAdmin
       return unless IronAdmin.configuration.current_user_block
 
       @iron_admin_current_user ||= instance_exec(self, &IronAdmin.configuration.current_user_block)
+    end
+
+    def iron_admin_filter_param(*keys)
+      iron_admin_param_dig(params[:filters], *keys)
+    end
+
+    def iron_admin_active_filter?(filter)
+      iron_admin_filter_param(filter[:name]).present? ||
+        iron_admin_filter_param("#{filter[:name]}_from").present? ||
+        iron_admin_filter_param("#{filter[:name]}_to").present? ||
+        (iron_admin_filter_param(filter[:name].to_s).is_a?(ActionController::Parameters) &&
+          iron_admin_filter_param(filter[:name].to_s, "value").present?)
+    end
+
+    def iron_admin_param_dig(value, *keys)
+      keys.reduce(value) do |current, key|
+        return nil unless current.is_a?(ActionController::Parameters) || current.is_a?(Hash)
+
+        current[key]
+      end
+    end
+
+    def render_not_found
+      head(:not_found)
+    end
+
+    def render_bad_request
+      head(:bad_request)
     end
   end
 end

--- a/app/controllers/iron_admin/concerns/filterable.rb
+++ b/app/controllers/iron_admin/concerns/filterable.rb
@@ -27,22 +27,22 @@ module IronAdmin
       end
 
       def apply_operator_filter(scope, filter)
-        sub = params.dig(:filters, filter[:name].to_s)
+        sub = iron_admin_filter_param(filter[:name].to_s)
         return scope unless sub.is_a?(ActionController::Parameters) && sub["value"].present?
 
         adapter.query_builder_class.call(scope, filter, sub.to_unsafe_h)
       end
 
       def apply_date_range_filter(scope, filter)
-        from = params.dig(:filters, "#{filter[:name]}_from")
-        to = params.dig(:filters, "#{filter[:name]}_to")
+        from = iron_admin_filter_param("#{filter[:name]}_from")
+        to = iron_admin_filter_param("#{filter[:name]}_to")
         scope = adapter.filter(scope, filter[:name], parse_date(from)..) if from.present? && parse_date(from)
         scope = adapter.filter(scope, filter[:name], ..parse_date(to)&.end_of_day) if to.present? && parse_date(to)
         scope
       end
 
       def apply_flat_filter(scope, filter)
-        value = params.dig(:filters, filter[:name])
+        value = iron_admin_filter_param(filter[:name])
         return scope if value.blank?
         return scope unless value.is_a?(String)
 

--- a/app/controllers/iron_admin/resources_controller.rb
+++ b/app/controllers/iron_admin/resources_controller.rb
@@ -204,9 +204,12 @@ module IronAdmin
       return render json: [] if query.blank?
 
       display = @resource_class.display_attribute
+      display = searchable_display_attribute unless adapter.has_column?(display)
+      return render json: [] unless display
+
       scope = adapter.search_column(base_scope, display, query)
       records = adapter.limit(scope, 20)
-        .map { |r| { id: r.id.to_s, label: r.public_send(display) } }
+        .map { |record| { id: record.to_param.to_s, label: record.public_send(display).to_s } }
 
       render json: records
     end
@@ -275,6 +278,10 @@ module IronAdmin
       end
     end
 
+    def searchable_display_attribute
+      @resource_class.searchable_columns.find { |column| adapter.has_column?(column) }
+    end
+
     def index_fields
       base_fields = if @resource_class.index_field_names
                       fields_by_name = @resource_class.resolved_fields.index_by(&:name)
@@ -298,7 +305,7 @@ module IronAdmin
 
     def purge_attachments(record)
       form_fields.select { |f| f.type == :file }.each do |field|
-        next unless params.dig(:record, :"#{field.name}_purge") == "1" && record.respond_to?(field.name)
+        next unless iron_admin_param_dig(params[:record], :"#{field.name}_purge") == "1" && record.respond_to?(field.name)
 
         record.public_send(field.name).then { |a| a.purge if a.attached? }
       end
@@ -320,7 +327,10 @@ module IronAdmin
         permitted << { "#{nested.name}_attributes": build_nested_permit_list(nested) }
       end
 
-      parsed = params.require(:record).permit(*permitted) # rubocop:disable Rails/StrongParametersExpect
+      record_params = params.require(:record)
+      raise ActionController::ParameterMissing, :record unless record_params.respond_to?(:permit)
+
+      parsed = record_params.permit(*permitted)
       coerce_json_field_params!(parsed)
       parsed
     end

--- a/app/views/iron_admin/resources/index.html.haml
+++ b/app/views/iron_admin/resources/index.html.haml
@@ -27,14 +27,14 @@
           = hidden_field_tag :scope, @current_scope
           - @resource_class.defined_filters.each do |filter|
             - if filter[:type].in?(%i[string number])
-              - sub = params.dig(:filters, filter[:name].to_s)
+              - sub = iron_admin_filter_param(filter[:name].to_s)
               - if sub.is_a?(ActionController::Parameters) && sub["value"].present?
                 = hidden_field_tag "filters[#{filter[:name]}][op]", sub["op"]
                 = hidden_field_tag "filters[#{filter[:name]}][value]", sub["value"]
                 - if sub["value_2"].present?
                   = hidden_field_tag "filters[#{filter[:name]}][value_2]", sub["value_2"]
             - else
-              - value = params.dig(:filters, filter[:name])
+              - value = iron_admin_filter_param(filter[:name])
               - if value.present?
                 = hidden_field_tag "filters[#{filter[:name]}]", value
           .relative
@@ -45,7 +45,7 @@
               class: cp_search_class
 
   - if @resource_class.defined_filters.any?
-    - has_active_filters = @resource_class.defined_filters.any? { |f| params.dig(:filters, f[:name]).present? || params.dig(:filters, "#{f[:name]}_from").present? || params.dig(:filters, "#{f[:name]}_to").present? || (params.dig(:filters, f[:name].to_s).is_a?(ActionController::Parameters) && params.dig(:filters, f[:name].to_s, "value").present?) }
+    - has_active_filters = @resource_class.defined_filters.any? { |f| iron_admin_active_filter?(f) }
     - select_chevron_style = "background-image: url(\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e\"); background-position: right 0.5rem center; background-repeat: no-repeat; background-size: 1.5em 1.5em; padding-right: 2.5rem;"
     .flex.justify-end.mb-4
       %details.relative.group{ open: has_active_filters || nil }
@@ -53,7 +53,7 @@
           = heroicon "funnel", variant: :mini, options: { class: "h-4 w-4 #{cp_muted_text}" }
           %span= I18n.t("iron_admin.resources.index.filters_label")
           - if has_active_filters
-            - active_count = @resource_class.defined_filters.count { |f| params.dig(:filters, f[:name]).present? || params.dig(:filters, "#{f[:name]}_from").present? || params.dig(:filters, "#{f[:name]}_to").present? || (params.dig(:filters, f[:name].to_s).is_a?(ActionController::Parameters) && params.dig(:filters, f[:name].to_s, "value").present?) }
+            - active_count = @resource_class.defined_filters.count { |f| iron_admin_active_filter?(f) }
             %span{ class: cp_badge_count }
               = active_count
           = heroicon "chevron-down", variant: :mini, options: { class: "h-4 w-4 text-gray-400 transition-transform group-open:rotate-180" }
@@ -71,24 +71,24 @@
                     %select.block.w-full.appearance-none.border.px-3.py-2.text-sm.shadow-sm.outline-none.transition.duration-150.ease-in-out{ name: "filters[#{filter[:name]}]", class: "#{t.border_radius} #{t.input_border} #{t.card_bg} #{cp_body_text} #{cp_focus}", style: select_chevron_style }
                       %option{ value: "" }= I18n.t("iron_admin.resources.index.all_option")
                       - filter_options_for(@resource_class, filter).each do |label, value|
-                        %option{ value: value, selected: params.dig(:filters, filter[:name]) == value.to_s }= label
+                        %option{ value: value, selected: iron_admin_filter_param(filter[:name]) == value.to_s }= label
                   - when :boolean
                     %select.block.w-full.appearance-none.border.px-3.py-2.text-sm.shadow-sm.outline-none.transition.duration-150.ease-in-out{ name: "filters[#{filter[:name]}]", class: "#{t.border_radius} #{t.input_border} #{t.card_bg} #{cp_body_text} #{cp_focus}", style: select_chevron_style }
                       %option{ value: "" }= I18n.t("iron_admin.resources.index.all_option")
                       - filter_options_for(@resource_class, filter).each do |label, value|
-                        %option{ value: value, selected: params.dig(:filters, filter[:name]) == value.to_s }= label
+                        %option{ value: value, selected: iron_admin_filter_param(filter[:name]) == value.to_s }= label
                   - when :date_range
                     .space-y-2
-                      = date_field_tag "filters[#{filter[:name]}_from]", params.dig(:filters, "#{filter[:name]}_from"),
+                      = date_field_tag "filters[#{filter[:name]}_from]", iron_admin_filter_param("#{filter[:name]}_from"),
                         class: cp_filter_input_class,
                         placeholder: I18n.t("iron_admin.filters.from")
-                      = date_field_tag "filters[#{filter[:name]}_to]", params.dig(:filters, "#{filter[:name]}_to"),
+                      = date_field_tag "filters[#{filter[:name]}_to]", iron_admin_filter_param("#{filter[:name]}_to"),
                         class: cp_filter_input_class,
                         placeholder: I18n.t("iron_admin.filters.to")
                   - when :string
                     - string_ops = %w[contains equals starts_with ends_with]
-                    - current_op = params.dig(:filters, filter[:name].to_s, "op") || "contains"
-                    - current_val = params.dig(:filters, filter[:name].to_s, "value") || ""
+                    - current_op = iron_admin_filter_param(filter[:name].to_s, "op") || "contains"
+                    - current_val = iron_admin_filter_param(filter[:name].to_s, "value") || ""
                     .space-y-2
                       %select.block.w-full.appearance-none.border.px-3.py-2.text-sm.shadow-sm.outline-none.transition.duration-150.ease-in-out{ name: "filters[#{filter[:name]}][op]", class: "#{t.border_radius} #{t.input_border} #{t.card_bg} #{cp_body_text} #{cp_focus}", style: select_chevron_style }
                         - string_ops.each do |op|
@@ -98,9 +98,9 @@
                         placeholder: filter[:label] || filter[:name].to_s.humanize
                   - when :number
                     - number_ops = %w[equals greater_than less_than between]
-                    - current_op = params.dig(:filters, filter[:name].to_s, "op") || "equals"
-                    - current_val = params.dig(:filters, filter[:name].to_s, "value") || ""
-                    - current_val_upper = params.dig(:filters, filter[:name].to_s, "value_2") || ""
+                    - current_op = iron_admin_filter_param(filter[:name].to_s, "op") || "equals"
+                    - current_val = iron_admin_filter_param(filter[:name].to_s, "value") || ""
+                    - current_val_upper = iron_admin_filter_param(filter[:name].to_s, "value_2") || ""
                     .space-y-2{ data: { controller: "filter-operator" } }
                       %select.block.w-full.appearance-none.border.px-3.py-2.text-sm.shadow-sm.outline-none.transition.duration-150.ease-in-out{ name: "filters[#{filter[:name]}][op]", class: "#{t.border_radius} #{t.input_border} #{t.card_bg} #{cp_body_text} #{cp_focus}", style: select_chevron_style, data: { action: "change->filter-operator#toggle", filter_operator_target: "opSelect" } }
                         - number_ops.each do |op|

--- a/spec/integration/edge_cases_spec.rb
+++ b/spec/integration/edge_cases_spec.rb
@@ -31,29 +31,29 @@ RSpec.describe "Edge Cases", type: :request do
   end
 
   describe "invalid record handling" do
-    it "raises error for non-existent record on show" do
-      expect do
-        get iron_admin.resource_path("users", 99_999)
-      end.to raise_error(IronAdmin::RecordNotFound)
+    it "returns not found for non-existent record on show" do
+      get iron_admin.resource_path("users", 99_999)
+
+      expect(response).to have_http_status(:not_found)
     end
 
-    it "raises error for non-existent record on edit" do
-      expect do
-        get iron_admin.edit_resource_path("users", 99_999)
-      end.to raise_error(IronAdmin::RecordNotFound)
+    it "returns not found for non-existent record on edit" do
+      get iron_admin.edit_resource_path("users", 99_999)
+
+      expect(response).to have_http_status(:not_found)
     end
 
-    it "raises error for non-existent record on update" do
-      expect do
-        patch iron_admin.resource_path("users", 99_999),
-              params: { record: { name: "Test" } }
-      end.to raise_error(IronAdmin::RecordNotFound)
+    it "returns not found for non-existent record on update" do
+      patch iron_admin.resource_path("users", 99_999),
+            params: { record: { name: "Test" } }
+
+      expect(response).to have_http_status(:not_found)
     end
 
-    it "raises error for non-existent record on destroy" do
-      expect do
-        delete iron_admin.resource_path("users", 99_999)
-      end.to raise_error(IronAdmin::RecordNotFound)
+    it "returns not found for non-existent record on destroy" do
+      delete iron_admin.resource_path("users", 99_999)
+
+      expect(response).to have_http_status(:not_found)
     end
   end
 

--- a/spec/requests/iron_admin/composite_primary_key_spec.rb
+++ b/spec/requests/iron_admin/composite_primary_key_spec.rb
@@ -23,16 +23,14 @@ RSpec.describe "IronAdmin composite primary key support", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
-    it "raises IronAdmin::RecordNotFound when the composite key has the wrong number of segments" do
-      expect do
-        get iron_admin.resource_path("memberships", "7"), as: :html
-      end.to raise_error(IronAdmin::RecordNotFound)
+    it "returns not found when the composite key has the wrong number of segments" do
+      get iron_admin.resource_path("memberships", "7"), as: :html
+      expect(response).to have_http_status(:not_found)
     end
 
-    it "raises IronAdmin::RecordNotFound when no record matches" do
-      expect do
-        get iron_admin.resource_path("memberships", "99_99"), as: :html
-      end.to raise_error(IronAdmin::RecordNotFound)
+    it "returns not found when no record matches" do
+      get iron_admin.resource_path("memberships", "99_99"), as: :html
+      expect(response).to have_http_status(:not_found)
     end
   end
 
@@ -40,6 +38,17 @@ RSpec.describe "IronAdmin composite primary key support", type: :request do
     it "renders the edit form for a composite-PK record" do
       get iron_admin.edit_resource_path("memberships", record.to_param), as: :html
       expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /autocomplete/:resource_name" do
+    it "searches a real text column and returns the composite key param" do
+      record
+
+      get iron_admin.autocomplete_path("memberships"), params: { q: "adm" }, as: :json
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to include("id" => record.to_param, "label" => "admin")
     end
   end
 end
@@ -59,10 +68,9 @@ RSpec.describe "IronAdmin custom (single-column) primary key support", type: :re
       expect(response).to have_http_status(:ok)
     end
 
-    it "raises IronAdmin::RecordNotFound when no record matches" do
-      expect do
-        get iron_admin.resource_path("slugged_resources", "missing-slug"), as: :html
-      end.to raise_error(IronAdmin::RecordNotFound)
+    it "returns not found when no record matches" do
+      get iron_admin.resource_path("slugged_resources", "missing-slug"), as: :html
+      expect(response).to have_http_status(:not_found)
     end
   end
 end

--- a/spec/requests/iron_admin/new_field_types_spec.rb
+++ b/spec/requests/iron_admin/new_field_types_spec.rb
@@ -157,6 +157,16 @@ RSpec.describe "New Field Types", type: :request do
 
       expect(existing.reload.cover_image).not_to be_attached
     end
+
+    it "returns bad request for array-shaped record params before purging attachments" do
+      existing = create(:document)
+
+      patch iron_admin.resource_path("documents", existing),
+            params: { record: ["bad"] },
+            as: :html
+
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 
   describe "DELETE /:resource_name/:id (destroy)" do

--- a/spec/requests/iron_admin/resources_spec.rb
+++ b/spec/requests/iron_admin/resources_spec.rb
@@ -370,6 +370,15 @@ RSpec.describe "IronAdmin::Resources", type: :request do
           expect(response.body).to include("KEY-FIVE")
         end
       end
+
+      context "with array-shaped filter params" do
+        it "returns success without rendering an exception" do
+          get "#{iron_admin.resources_path("number_filter_licenses")}?filters[max_devices][]=1&filters[max_devices][]=2",
+              as: :html
+
+          expect(response).to have_http_status(:ok)
+        end
+      end
     end
 
     context "with scopes" do
@@ -744,6 +753,11 @@ RSpec.describe "IronAdmin::Resources", type: :request do
       expect(response).to have_http_status(:ok)
     end
 
+    it "returns not found for a missing record" do
+      get iron_admin.resource_path("users", "missing"), as: :html
+      expect(response).to have_http_status(:not_found)
+    end
+
     context "with has_one association" do
       before do
         IronAdmin::ResourceRegistry.register(IronAdmin::Resources::ProfileResource)
@@ -890,6 +904,11 @@ RSpec.describe "IronAdmin::Resources", type: :request do
       get iron_admin.edit_resource_path("users", user), as: :html
       expect(response).to have_http_status(:ok)
     end
+
+    it "returns not found for a missing record" do
+      get iron_admin.edit_resource_path("users", "missing"), as: :html
+      expect(response).to have_http_status(:not_found)
+    end
   end
 
   describe "POST /:resource_name" do
@@ -961,6 +980,22 @@ RSpec.describe "IronAdmin::Resources", type: :request do
               as: :html
         expect(response).to have_http_status(:unprocessable_content)
       end
+
+      it "returns bad request for array-shaped record params" do
+        patch iron_admin.resource_path("users", user),
+              params: { record: ["bad"] },
+              as: :html
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context "with a missing record" do
+      it "returns not found" do
+        patch iron_admin.resource_path("users", "missing"),
+              params: { record: { name: "New Name", email: user.email, role: user.role } },
+              as: :html
+        expect(response).to have_http_status(:not_found)
+      end
     end
 
     context "with on_action callback" do
@@ -991,6 +1026,11 @@ RSpec.describe "IronAdmin::Resources", type: :request do
     it "redirects to index" do
       delete iron_admin.resource_path("users", user), as: :html
       expect(response).to redirect_to(iron_admin.resources_path("users"))
+    end
+
+    it "returns not found for a missing record" do
+      delete iron_admin.resource_path("users", "missing"), as: :html
+      expect(response).to have_http_status(:not_found)
     end
 
     context "with on_action callback" do
@@ -2266,35 +2306,35 @@ RSpec.describe "IronAdmin::Resources", type: :request do
       it "prevents cross-tenant record access on show" do
         inactive_user = create(:user, name: "Inactive User", active: false)
 
-        expect do
-          get iron_admin.resource_path("users", inactive_user), as: :html
-        end.to raise_error(IronAdmin::RecordNotFound)
+        get iron_admin.resource_path("users", inactive_user), as: :html
+
+        expect(response).to have_http_status(:not_found)
       end
 
       it "prevents cross-tenant record access on edit" do
         inactive_user = create(:user, name: "Inactive User", active: false)
 
-        expect do
-          get iron_admin.edit_resource_path("users", inactive_user), as: :html
-        end.to raise_error(IronAdmin::RecordNotFound)
+        get iron_admin.edit_resource_path("users", inactive_user), as: :html
+
+        expect(response).to have_http_status(:not_found)
       end
 
       it "prevents cross-tenant record access on update" do
         inactive_user = create(:user, name: "Inactive User", active: false)
 
-        expect do
-          patch iron_admin.resource_path("users", inactive_user),
-                params: { record: { name: "New Name", email: inactive_user.email, role: inactive_user.role } },
-                as: :html
-        end.to raise_error(IronAdmin::RecordNotFound)
+        patch iron_admin.resource_path("users", inactive_user),
+              params: { record: { name: "New Name", email: inactive_user.email, role: inactive_user.role } },
+              as: :html
+
+        expect(response).to have_http_status(:not_found)
       end
 
       it "prevents cross-tenant record access on destroy" do
         inactive_user = create(:user, name: "Inactive User", active: false)
 
-        expect do
-          delete iron_admin.resource_path("users", inactive_user), as: :html
-        end.to raise_error(IronAdmin::RecordNotFound)
+        delete iron_admin.resource_path("users", inactive_user), as: :html
+
+        expect(response).to have_http_status(:not_found)
       end
 
       it "applies tenant scope to bulk actions" do


### PR DESCRIPTION
Part of #98.

## Summary
- Return 404 instead of raising for missing records and scoped-out records.
- Return 400 for malformed `record` params instead of allowing controller TypeError/NoMethodError paths.
- Read filter params defensively so array-shaped filter values do not crash the index view.
- Avoid composite-primary-key autocomplete searches against nonexistent `id` columns and return `to_param` ids.

## Verification
- `bundle exec rspec` -> 1934 examples, 0 failures, 96.57% coverage.
- `bundle exec rubocop` -> no offenses.
- Focused specs for resources, composite primary keys, edge cases, and new field types pass; subset commands exit nonzero only because SimpleCov enforces global coverage on partial runs.

## SDD Review
- Independent reviewer pass completed after addressing one important finding in attachment purge handling; no remaining blockers.