### PR TITLE
Fix filter, search, and export consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Filtering, search, and export consistency** (#98) — CSV/JSON exports now apply the same filters, search query, scopes, sort order, tenant scope, and preloading as index views for ActiveRecord and Mongoid resources. Auto-inferred filters now render in the index UI while respecting field visibility, select filters with scalar string options render usable labels and values, field-specific string searches containing `..` no longer expand to an unfiltered result set, and ActiveRecord search now finds literal `%` and `_` characters.
 - **Controller hardening for malformed params and missing records** (#98) — Resource show/edit/update/destroy now return 404 for missing or inaccessible records instead of surfacing `IronAdmin::RecordNotFound`; malformed array-shaped `record` params now return 400; array-shaped numeric filter params no longer crash the index view; composite-primary-key autocomplete now searches a real text column fallback and returns `to_param` ids.
 - **Nested association JSON fields** (#86) — Nested forms now render `:json` child fields as pretty-printed textareas and coerce both `has_many`-style and `has_one`-style nested `*_attributes` JSON strings back into structured values.
 - **Polymorphic type inference in lazy-loaded ActiveRecord apps** (#84) — Polymorphic inverse discovery moved behind adapter hooks and ActiveRecord eager-loads model paths before scanning descendants.

--- a/app/controllers/iron_admin/concerns/filterable.rb
+++ b/app/controllers/iron_admin/concerns/filterable.rb
@@ -9,6 +9,10 @@ module IronAdmin
     module Filterable
       extend ActiveSupport::Concern
 
+      included do
+        helper_method :iron_admin_visible_filters if respond_to?(:helper_method)
+      end
+
       private
 
       # Applies all configured filters to the scope.
@@ -16,7 +20,7 @@ module IronAdmin
       # @param scope [Object] Base query scope (ActiveRecord::Relation or Mongoid::Criteria)
       # @return [Object] Filtered scope
       def apply_filters(scope)
-        @resource_class.all_filters.each do |filter|
+        iron_admin_visible_filters.each do |filter|
           scope = case filter[:type]
                   when :string, :number then apply_operator_filter(scope, filter)
                   when :date_range then apply_date_range_filter(scope, filter)
@@ -24,6 +28,19 @@ module IronAdmin
                   end
         end
         scope
+      end
+
+      def iron_admin_visible_filters
+        @iron_admin_visible_filters ||= begin
+          resolved_fields = @resource_class.resolved_fields
+          resolved_names = resolved_fields.map(&:name)
+          visible_names = resolved_fields.select { |field| field.visible?(iron_admin_current_user) }.map(&:name)
+
+          @resource_class.all_filters.select do |filter|
+            filter_name = filter[:name].to_sym
+            resolved_names.exclude?(filter_name) || visible_names.include?(filter_name)
+          end
+        end
       end
 
       def apply_operator_filter(scope, filter)

--- a/app/controllers/iron_admin/concerns/scopeable.rb
+++ b/app/controllers/iron_admin/concerns/scopeable.rb
@@ -15,6 +15,13 @@ module IronAdmin
         scope
       end
 
+      def collection_scope
+        scope = apply_scopes(apply_filters(base_scope))
+        scope = apply_search(scope)
+        scope = apply_sorting(scope)
+        apply_preloading(scope)
+      end
+
       def record_scope
         scope = base_scope
         scope = adapter.unscope_column(scope, @resource_class.soft_delete_column) if @resource_class.soft_delete?
@@ -36,6 +43,41 @@ module IronAdmin
         raise IronAdmin::RecordNotFound unless result
 
         result
+      end
+
+      def current_scope_name
+        scope_name = params[:scope]
+        defined_scope = @resource_class.all_scopes.find { |s| s[:name].to_s == scope_name }
+        defined_scope ||= @resource_class.all_scopes.find { |s| s[:default] }
+        defined_scope&.dig(:name)&.to_s
+      end
+
+      def apply_scopes(scope)
+        defined_scope = @resource_class.all_scopes.find { |s| s[:name].to_s == params[:scope] }
+        defined_scope ||= @resource_class.all_scopes.find { |s| s[:default] }
+
+        return scope unless defined_scope
+
+        apply_resource_scope(scope, defined_scope[:scope])
+      end
+
+      def apply_resource_scope(scope, scope_body)
+        return scope.merge(scope_body) unless scope_body.respond_to?(:call)
+
+        scope_body.arity.zero? ? scope.instance_exec(&scope_body) : scope_body.call(scope)
+      end
+
+      def apply_sorting(scope)
+        sort_col = params[:sort].to_s
+        sort_col = IronAdmin.configuration.default_sort.to_s unless adapter.has_column?(sort_col)
+        valid_dir = %w[asc desc].include?(params[:direction].to_s.downcase)
+        sort_dir = valid_dir ? params[:direction] : IronAdmin.configuration.default_sort_direction
+        adapter.order_by(scope, sort_col, sort_dir)
+      end
+
+      def apply_preloading(scope)
+        preloads = @resource_class.preload_associations
+        preloads.any? ? adapter.preload(scope, preloads) : scope
       end
     end
   end

--- a/app/controllers/iron_admin/concerns/searchable.rb
+++ b/app/controllers/iron_admin/concerns/searchable.rb
@@ -32,7 +32,7 @@ module IronAdmin
         return scope unless adapter.has_column?(field)
         return scope unless field_visible?(field.to_sym)
 
-        if value.include?("..")
+        if value.include?("..") && range_search_column?(field)
           from_str, to_str = value.split("..", 2)
           from_date = parse_date(from_str)
           to_date = parse_date(to_str)
@@ -45,6 +45,12 @@ module IronAdmin
         end
 
         adapter.search_column(scope, field, value)
+      end
+
+      def range_search_column?(field)
+        adapter.columns.any? do |column|
+          column.name.to_s == field.to_s && column.type.in?(%i[date datetime])
+        end
       end
 
       def apply_general_search(scope, query)

--- a/app/controllers/iron_admin/exports_controller.rb
+++ b/app/controllers/iron_admin/exports_controller.rb
@@ -9,13 +9,17 @@ module IronAdmin
   # @see IronAdmin::Resource#exports
   # @see IronAdmin::Resource#export_fields
   class ExportsController < ApplicationController
+    include Concerns::Filterable
+    include Concerns::Scopeable
+    include Concerns::Searchable
+
     before_action :set_resource_class
 
     # Exports resource data in the requested format.
     #
     # @return [void] Sends CSV file or renders JSON
     def show
-      records = base_scope
+      records = collection_scope
       fields = export_fields
 
       respond_to do |format|
@@ -42,12 +46,6 @@ module IronAdmin
 
     def adapter
       @resource_class.adapter
-    end
-
-    def base_scope
-      scope = adapter.all
-      scope = IronAdmin.configuration.tenant_scope_block.call(scope) if IronAdmin.configuration.tenant_scope_block
-      scope
     end
 
     def export_fields

--- a/app/controllers/iron_admin/resources_controller.rb
+++ b/app/controllers/iron_admin/resources_controller.rb
@@ -34,12 +34,7 @@ module IronAdmin
     #
     # @return [void]
     def index
-      scope = apply_scopes(apply_filters(base_scope))
-      scope = apply_search(scope)
-      scope = apply_sorting(scope)
-      scope = apply_preloading(scope)
-
-      @pagy, @records = pagy(scope, limit: IronAdmin.configuration.per_page)
+      @pagy, @records = pagy(collection_scope, limit: IronAdmin.configuration.per_page)
       @fields = index_fields
       @current_scope = current_scope_name
     end
@@ -333,35 +328,6 @@ module IronAdmin
       parsed = record_params.permit(*permitted)
       coerce_json_field_params!(parsed)
       parsed
-    end
-
-    def current_scope_name
-      scope_name = params[:scope]
-      defined_scope = @resource_class.all_scopes.find { |s| s[:name].to_s == scope_name }
-      defined_scope ||= @resource_class.all_scopes.find { |s| s[:default] }
-      defined_scope&.dig(:name)&.to_s
-    end
-
-    def apply_scopes(scope)
-      defined_scope = @resource_class.all_scopes.find { |s| s[:name].to_s == params[:scope] }
-      defined_scope ||= @resource_class.all_scopes.find { |s| s[:default] }
-
-      return scope unless defined_scope
-
-      scope.merge(defined_scope[:scope])
-    end
-
-    def apply_sorting(scope)
-      sort_col = params[:sort].to_s
-      sort_col = IronAdmin.configuration.default_sort.to_s unless adapter.has_column?(sort_col)
-      valid_dir = %w[asc desc].include?(params[:direction].to_s.downcase)
-      sort_dir = valid_dir ? params[:direction] : IronAdmin.configuration.default_sort_direction
-      adapter.order_by(scope, sort_col, sort_dir)
-    end
-
-    def apply_preloading(scope)
-      preloads = @resource_class.preload_associations
-      preloads.any? ? adapter.preload(scope, preloads) : scope
     end
 
     def emit_event(action, record)

--- a/app/helpers/iron_admin/application_helper.rb
+++ b/app/helpers/iron_admin/application_helper.rb
@@ -113,7 +113,7 @@ module IronAdmin
         if enums.key?(column_name)
           enums[column_name].keys.map { |k| [k.humanize, k] }
         elsif filter[:options]
-          filter[:options]
+          normalize_filter_options(filter[:options])
         else
           resource_adapter.distinct_values(column_name).map { |v| [v.to_s.humanize, v] }
         end
@@ -121,6 +121,12 @@ module IronAdmin
         [[I18n.t("iron_admin.filters.true"), "true"], [I18n.t("iron_admin.filters.false"), "false"]]
       else
         []
+      end
+    end
+
+    def normalize_filter_options(options)
+      options.map do |option|
+        option.is_a?(Array) ? option : [option.to_s.humanize, option]
       end
     end
   end

--- a/app/views/iron_admin/resources/index.html.haml
+++ b/app/views/iron_admin/resources/index.html.haml
@@ -1,3 +1,5 @@
+- filters = iron_admin_visible_filters
+
 .p-8.max-w-7xl.mx-auto{ class: t.font_family }
   .flex.items-center.justify-between.mb-6
     %h1.text-2xl{ class: cp_heading }= @resource_class.label
@@ -25,7 +27,7 @@
       - if @resource_class.searchable_columns.any?
         = form_tag resources_path(@resource_class.resource_name), method: :get, class: "flex ml-auto" do
           = hidden_field_tag :scope, @current_scope
-          - @resource_class.defined_filters.each do |filter|
+          - filters.each do |filter|
             - if filter[:type].in?(%i[string number])
               - sub = iron_admin_filter_param(filter[:name].to_s)
               - if sub.is_a?(ActionController::Parameters) && sub["value"].present?
@@ -44,8 +46,8 @@
               placeholder: I18n.t("iron_admin.resources.index.search_placeholder"),
               class: cp_search_class
 
-  - if @resource_class.defined_filters.any?
-    - has_active_filters = @resource_class.defined_filters.any? { |f| iron_admin_active_filter?(f) }
+  - if filters.any?
+    - has_active_filters = filters.any? { |f| iron_admin_active_filter?(f) }
     - select_chevron_style = "background-image: url(\"data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e\"); background-position: right 0.5rem center; background-repeat: no-repeat; background-size: 1.5em 1.5em; padding-right: 2.5rem;"
     .flex.justify-end.mb-4
       %details.relative.group{ open: has_active_filters || nil }
@@ -53,7 +55,7 @@
           = heroicon "funnel", variant: :mini, options: { class: "h-4 w-4 #{cp_muted_text}" }
           %span= I18n.t("iron_admin.resources.index.filters_label")
           - if has_active_filters
-            - active_count = @resource_class.defined_filters.count { |f| iron_admin_active_filter?(f) }
+            - active_count = filters.count { |f| iron_admin_active_filter?(f) }
             %span{ class: cp_badge_count }
               = active_count
           = heroicon "chevron-down", variant: :mini, options: { class: "h-4 w-4 text-gray-400 transition-transform group-open:rotate-180" }
@@ -62,7 +64,7 @@
             = hidden_field_tag :scope, @current_scope
             = hidden_field_tag :q, params[:q]
             .space-y-3
-              - @resource_class.defined_filters.each do |filter|
+              - filters.each do |filter|
                 .space-y-1
                   %label.block.text-xs.font-semibold.uppercase.tracking-wider{ class: cp_muted_text }
                     = filter[:name].to_s.humanize

--- a/lib/iron_admin/adapters/active_record.rb
+++ b/lib/iron_admin/adapters/active_record.rb
@@ -111,12 +111,14 @@ module IronAdmin
       def search_column(scope, column, query)
         table = quoted_table_name
         col = connection.quote_column_name(column)
-        scope.where("#{table}.#{col} #{like_operator} ?", "%#{sanitize_like(query)}%")
+        scope.where("#{table}.#{col} #{like_operator} ? #{like_escape_clause}", "%#{sanitize_like(query)}%")
       end
 
       def search_columns(scope, columns, query)
         table = quoted_table_name
-        conditions = columns.map { |col| "#{table}.#{connection.quote_column_name(col)} #{like_operator} :q" }
+        conditions = columns.map do |col|
+          "#{table}.#{connection.quote_column_name(col)} #{like_operator} :q #{like_escape_clause}"
+        end
         scope.where(conditions.join(" OR "), q: "%#{sanitize_like(query)}%")
       end
 
@@ -196,6 +198,10 @@ module IronAdmin
 
       def like_operator
         postgresql? ? "ILIKE" : "LIKE"
+      end
+
+      def like_escape_clause
+        "ESCAPE '\\'"
       end
 
       def sanitize_like(value)

--- a/spec/helpers/iron_admin/application_helper_spec.rb
+++ b/spec/helpers/iron_admin/application_helper_spec.rb
@@ -427,6 +427,16 @@ RSpec.describe IronAdmin::ApplicationHelper, type: :helper do
       end
     end
 
+    context "with select filter with scalar string options" do
+      let(:filter) { { name: :role, type: :select, options: %w[enterprise standard] } }
+
+      it "normalizes options into label-value pairs" do
+        options = helper.filter_options_for(IronAdmin::Resources::UserResource, filter)
+
+        expect(options).to eq([%w[Enterprise enterprise], %w[Standard standard]])
+      end
+    end
+
     context "with select filter on regular column" do
       before do
         create(:user, role: "admin")

--- a/spec/requests/iron_admin/exports_spec.rb
+++ b/spec/requests/iron_admin/exports_spec.rb
@@ -10,6 +10,207 @@ RSpec.describe "IronAdmin::Exports", type: :request do
     IronAdmin::ResourceRegistry.register(IronAdmin::Resources::LicenseResource)
   end
 
+  describe "query consistency" do
+    let(:user) { create(:user) }
+
+    it "applies select filters to JSON exports" do
+      create(:user, name: "Enterprise User", email: "enterprise@example.com", role: "admin")
+      create(:user, name: "Starter User", email: "starter@example.com", role: "member")
+
+      get iron_admin.export_path("users", format: :json), params: { filters: { role: "admin" } }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.pluck("name")).to contain_exactly("Enterprise User")
+    end
+
+    it "applies search to JSON exports" do
+      create(:user, name: "Findable User", email: "findable@example.com")
+      create(:user, name: "Hidden User", email: "hidden@example.com")
+
+      get iron_admin.export_path("users", format: :json), params: { q: "Findable" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.pluck("name")).to contain_exactly("Findable User")
+    end
+
+    it "applies search to CSV exports" do
+      create(:user, name: "CSV Findable User", email: "csv-findable@example.com")
+      create(:user, name: "CSV Hidden User", email: "csv-hidden@example.com")
+
+      get iron_admin.export_path("users", format: :csv), params: { q: "CSV Findable" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("CSV Findable User")
+      expect(response.body).not_to include("CSV Hidden User")
+    end
+
+    it "applies scopes to JSON exports" do
+      active = create(:license, user: user, status: "active", license_key: "ACTIVE-SCOPE")
+      expired = create(:license, user: user, status: "expired", license_key: "EXPIRED-SCOPE")
+
+      get iron_admin.export_path("licenses", format: :json), params: { scope: "expired" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.pluck("license_key")).to contain_exactly(expired.license_key)
+      expect(response.parsed_body.pluck("license_key")).not_to include(active.license_key)
+    end
+
+    it "applies sorting to JSON exports" do
+      create(:user, name: "Zulu User", email: "zulu@example.com")
+      create(:user, name: "Alpha User", email: "alpha@example.com")
+
+      get iron_admin.export_path("users", format: :json), params: { sort: "name", direction: "asc" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.pluck("name")).to eq(["Alpha User", "Zulu User"])
+    end
+  end
+
+  describe "Mongoid query consistency" do
+    let(:fake_mongo_article_class) do
+      Struct.new(:_id, :title, :status, :created_at, keyword_init: true)
+    end
+
+    let(:fake_mongo_criteria_class) do
+      Class.new do
+        include Enumerable
+
+        attr_reader :records, :selector, :options
+
+        def initialize(records, selector: {}, options: {})
+          @records = records
+          @selector = selector
+          @options = options
+        end
+
+        def each(&)
+          records.each(&)
+        end
+
+        def where(condition)
+          matching_records = records.select { |record| matches?(record, condition) }
+          self.class.new(matching_records, selector: selector.merge(condition), options: options)
+        end
+
+        def any_of(*conditions)
+          matching_records = records.select do |record|
+            conditions.any? { |condition| matches?(record, condition) }
+          end
+          self.class.new(matching_records, selector: selector, options: options)
+        end
+
+        def order_by(order)
+          column, direction = order.first
+          sorted = records.sort_by { |record| record.public_send(column) }
+          sorted.reverse! if direction.to_s == "desc"
+          self.class.new(sorted, selector: selector, options: options.merge(sort: order))
+        end
+
+        def limit(max)
+          self.class.new(records.first(max), selector: selector, options: options)
+        end
+
+        def batch_size(_size)
+          self
+        end
+
+        def merge(scope)
+          self.class.new(records & scope.records, selector: selector.merge(scope.selector), options: options)
+        end
+
+        private
+
+        def matches?(record, condition)
+          condition.all? do |field, expected|
+            value = record.public_send(field)
+            expected.is_a?(Regexp) ? value.to_s.match?(expected) : value == expected
+          end
+        end
+      end
+    end
+
+    let(:fake_mongo_article_model) do
+      criteria_class = fake_mongo_criteria_class
+      field_class = Struct.new(:name, :type)
+
+      Class.new do
+        define_singleton_method(:records) { @records }
+        define_singleton_method(:records=) { |records| @records = records }
+        define_singleton_method(:relations) { {} }
+        define_singleton_method(:collection_name) { "mongo_articles" }
+        define_singleton_method(:model_name) { ActiveModel::Name.new(self, nil, "MongoArticle") }
+        define_singleton_method(:all) { criteria_class.new(records) }
+
+        define_singleton_method(:fields) do
+          {
+            "_id" => field_class.new("_id", Object),
+            "title" => field_class.new("title", String),
+            "status" => field_class.new("status", String),
+            "created_at" => field_class.new("created_at", Time),
+          }
+        end
+      end
+    end
+
+    let(:mongo_article_resource) do
+      model_class = fake_mongo_article_model
+
+      Class.new(IronAdmin::Resource) do
+        self.adapter_class = :mongoid
+        self.model_class_override = model_class
+
+        def self.name
+          "FakeMongoArticleResource"
+        end
+
+        def self.resource_name
+          "mongo_articles"
+        end
+
+        searchable :title
+        filter :status, type: :select, options: %w[draft published]
+        scope :drafts, -> { where(status: "draft") }
+        export_fields :title, :status
+      end
+    end
+
+    before do
+      fake_mongo_article_model.records = [
+        fake_mongo_article_class.new(_id: "1", title: "Beta Draft", status: "draft", created_at: 2.days.ago),
+        fake_mongo_article_class.new(_id: "2", title: "Alpha Published", status: "published", created_at: 1.day.ago),
+      ]
+      IronAdmin::ResourceRegistry.register(mongo_article_resource)
+    end
+
+    it "applies filters to JSON exports" do
+      get iron_admin.export_path("mongo_articles", format: :json), params: { filters: { status: "draft" } }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.pluck("title")).to contain_exactly("Beta Draft")
+    end
+
+    it "applies scopes to JSON exports" do
+      get iron_admin.export_path("mongo_articles", format: :json), params: { scope: "drafts" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.pluck("title")).to contain_exactly("Beta Draft")
+    end
+
+    it "applies search to JSON exports" do
+      get iron_admin.export_path("mongo_articles", format: :json), params: { q: "NO_SUCH_TERM" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body).to eq([])
+    end
+
+    it "applies sorting to JSON exports" do
+      get iron_admin.export_path("mongo_articles", format: :json), params: { sort: "title", direction: "asc" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.parsed_body.pluck("title")).to eq(["Alpha Published", "Beta Draft"])
+    end
+  end
+
   describe "field visibility enforcement" do
     let(:visibility_resource) do
       Class.new(IronAdmin::Resource) do
@@ -67,6 +268,18 @@ RSpec.describe "IronAdmin::Exports", type: :request do
         expect(json.first.keys).to include("name")
         expect(json.first.keys).not_to include("email")
         expect(json.first.keys).not_to include("role")
+      end
+
+      it "does not apply invisible field filters from crafted params to JSON export" do
+        create(:user, name: "Secret Export User", email: "secret-export@example.com", role: "admin")
+        create(:user, name: "Normal Export User", email: "normal-export@example.com", role: "admin")
+
+        get iron_admin.export_path("export_visibility_users", format: :json),
+            params: { filters: { email: { op: "contains", value: "secret-export" } } }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.parsed_body.pluck("name")).to contain_exactly("Secret Export User", "Normal Export User")
+        expect(response.parsed_body.flat_map(&:keys)).not_to include("email")
       end
 
       it "excludes invisible field headers from CSV export" do

--- a/spec/requests/iron_admin/resources_spec.rb
+++ b/spec/requests/iron_admin/resources_spec.rb
@@ -64,6 +64,17 @@ RSpec.describe "IronAdmin::Resources", type: :request do
         get iron_admin.resources_path("users"), params: { q: "name:Test User" }, as: :html
         expect(response).to have_http_status(:ok)
       end
+
+      it "does not treat non-date string values containing range syntax as an unfiltered scope" do
+        create(:user, name: "Visible Alpha", email: "alpha@example.com")
+        create(:user, name: "Visible Beta", email: "beta@example.com")
+
+        get iron_admin.resources_path("users"), params: { q: "name:definitelynomatch..alsonope" }, as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).not_to include("Visible Alpha")
+        expect(response.body).not_to include("Visible Beta")
+      end
     end
 
     context "with date range search (field:from..to syntax)" do
@@ -147,6 +158,28 @@ RSpec.describe "IronAdmin::Resources", type: :request do
         get iron_admin.resources_path("users"), params: { q: "   " }, as: :html
         expect(response).to have_http_status(:ok)
       end
+
+      it "finds literal percent characters" do
+        create(:user, name: "Percent 100% Match", email: "percent@example.com")
+        create(:user, name: "Percent 100X Match", email: "percent-wildcard@example.com")
+
+        get iron_admin.resources_path("users"), params: { q: "100%" }, as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Percent 100% Match")
+        expect(response.body).not_to include("Percent 100X Match")
+      end
+
+      it "finds literal underscore characters" do
+        create(:user, name: "Underscore A_B Match", email: "underscore@example.com")
+        create(:user, name: "Underscore AXB Match", email: "underscore-wildcard@example.com")
+
+        get iron_admin.resources_path("users"), params: { q: "A_B" }, as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Underscore A_B Match")
+        expect(response.body).not_to include("Underscore AXB Match")
+      end
     end
 
     context "with sorting" do
@@ -169,6 +202,35 @@ RSpec.describe "IronAdmin::Resources", type: :request do
         create(:user, role: "member")
         get iron_admin.resources_path("users"), params: { filters: { role: "admin" } }, as: :html
         expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "with auto-inferred filters" do
+      let(:auto_filter_resource) do
+        Class.new(IronAdmin::Resource) do
+          self.model_class_override = User
+
+          def self.name
+            "AutoFilterUserResource"
+          end
+
+          def self.resource_name
+            "auto_filter_users"
+          end
+        end
+      end
+
+      before do
+        IronAdmin::ResourceRegistry.register(auto_filter_resource)
+        create(:user, name: "Auto Filtered", email: "auto-filtered@example.com")
+      end
+
+      it "renders controls for filters inferred from searchable string columns" do
+        get iron_admin.resources_path("auto_filter_users"), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('name="filters[name][value]"')
+        expect(response.body).to include('name="filters[email][value]"')
       end
     end
 
@@ -1477,6 +1539,19 @@ RSpec.describe "IronAdmin::Resources", type: :request do
         # (not just the one with matching email - that would leak data)
         expect(response.body).to include("Secret Email User")
         expect(response.body).to include("Normal Email User")
+      end
+
+      it "does not apply invisible field filters from crafted params" do
+        create(:user, name: "Secret Filter User", email: "secret-filter@example.com")
+        create(:user, name: "Normal Filter User", email: "normal-filter@example.com")
+
+        get iron_admin.resources_path("visibility_users"),
+            params: { filters: { email: { op: "contains", value: "secret-filter" } } },
+            as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Secret Filter User")
+        expect(response.body).to include("Normal Filter User")
       end
 
       it "searches visible fields with field:value syntax" do


### PR DESCRIPTION
Part of #98.

## Summary
- Apply the same filters, search, scopes, sort order, tenant scope, and preloading to CSV/JSON exports as index views.
- Share the collection query pipeline between resource index and exports.
- Restrict server-side filters to fields visible to the current user, including crafted filter params.
- Render auto-inferred visible filters in the index UI and normalize scalar select filter options.
- Treat `..` as range search only for date/datetime fields.
- Escape ActiveRecord LIKE wildcards so literal `%` and `_` searches work.

## Verification
- `bundle exec rspec` -> 1950 examples, 0 failures, 96.64% coverage.
- `bundle exec rubocop` -> no offenses.
- Focused category specs pass; subset command exits nonzero only because SimpleCov enforces global coverage on partial runs.

## SDD Review
- Independent review found hidden filter bypass and Mongoid fake-scope false positive; both were fixed and re-reviewed with no remaining blockers.