### PR TITLE
Fix belongs_to form associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,7 @@ First public release.
 
 ### Fixed
 
+- Category D: belongs_to form fields now honor `autocomplete: true` and tenant-scoped select options.
 - Export error handling for missing fields and type coercion
 - Custom actions wrapped in database transactions with proper error handling
 - Date filter parsing for invalid dates

--- a/app/helpers/iron_admin/application_helper.rb
+++ b/app/helpers/iron_admin/application_helper.rb
@@ -129,5 +129,13 @@ module IronAdmin
         option.is_a?(Array) ? option : [option.to_s.humanize, option]
       end
     end
+
+    def association_resource_for(field, association_class)
+      resource = field.options[:resource]
+      return resource.constantize if resource.is_a?(String)
+      return resource if resource
+
+      IronAdmin::ResourceRegistry.find(association_class.model_name.plural)
+    end
   end
 end

--- a/app/views/iron_admin/resources/_form.html.haml
+++ b/app/views/iron_admin/resources/_form.html.haml
@@ -18,11 +18,21 @@
           - assoc_class = field.options[:association_class]
           - fk = field.options[:foreign_key]
           - display_method = field.options[:display]
-          - belongs_to_options = assoc_class.all.map { |r| [display_record_label(r, display_method), r.id] }
-          = f.select fk,
-            options_for_select(belongs_to_options, @record.public_send(fk)),
-            { include_blank: I18n.t("iron_admin.fields.select_placeholder") },
-            class: [cp_select_class, (error_input_class if has_error)].compact.join(" ")
+          - association_resource = association_resource_for(field, assoc_class)
+          - if field.options[:autocomplete]
+            - selected_record = @record.public_send(field.name) if @record.respond_to?(field.name)
+            - autocomplete_resource_name = association_resource&.resource_name || assoc_class.model_name.route_key
+            - autocomplete_component = IronAdmin::Form::BelongsToAutocompleteComponent.new(name: "record[#{fk}]", resource_name: autocomplete_resource_name, selected_id: @record.public_send(fk), selected_label: selected_record ? display_record_label(selected_record, display_method) : nil, has_error: has_error)
+            = render autocomplete_component
+          - else
+            - belongs_to_scope = assoc_class.all
+            - tenant_scope = IronAdmin.configuration.tenant_scope_block
+            - belongs_to_scope = tenant_scope.call(belongs_to_scope) if tenant_scope
+            - belongs_to_options = belongs_to_scope.map { |r| [display_record_label(r, display_method), r.id] }
+            = f.select fk,
+              options_for_select(belongs_to_options, @record.public_send(fk)),
+              { include_blank: I18n.t("iron_admin.fields.select_placeholder") },
+              class: [cp_select_class, (error_input_class if has_error)].compact.join(" ")
         - when :text
           = f.text_field field.name, placeholder: field.name.to_s.humanize,
             class: [cp_input_class, (error_input_class if has_error)].compact.join(" ")

--- a/spec/requests/iron_admin/resources_spec.rb
+++ b/spec/requests/iron_admin/resources_spec.rb
@@ -971,6 +971,116 @@ RSpec.describe "IronAdmin::Resources", type: :request do
       get iron_admin.edit_resource_path("users", "missing"), as: :html
       expect(response).to have_http_status(:not_found)
     end
+
+    context "with belongs_to autocomplete configured" do
+      let(:autocomplete_user_resource) do
+        Class.new(IronAdmin::Resource) do
+          self.model_class_override = User
+
+          def self.name
+            "AutocompleteTargetUserResource"
+          end
+
+          def self.resource_name
+            "autocomplete_target_users"
+          end
+        end
+      end
+
+      let(:autocomplete_license_resource) do
+        target_resource = autocomplete_user_resource
+
+        Class.new(IronAdmin::Resource) do
+          self.model_class_override = License
+
+          def self.name
+            "AutocompleteLicenseResource"
+          end
+
+          def self.resource_name
+            "autocomplete_licenses"
+          end
+
+          belongs_to :user, display: :email, autocomplete: true, resource: target_resource
+          form_fields :user
+        end
+      end
+
+      before do
+        IronAdmin::ResourceRegistry.register(autocomplete_user_resource)
+        IronAdmin::ResourceRegistry.register(autocomplete_license_resource)
+      end
+
+      after do
+        IronAdmin::ResourceRegistry.reset!
+        IronAdmin::ResourceRegistry.register(IronAdmin::Resources::UserResource)
+        IronAdmin::ResourceRegistry.register(IronAdmin::Resources::LicenseResource)
+      end
+
+      it "renders the autocomplete belongs_to input with the current selection" do
+        user = create(:user, email: "selected@example.com")
+        license = create(:license, user: user)
+
+        get iron_admin.edit_resource_path("autocomplete_licenses", license), as: :html
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include('data-autocomplete-url="/admin/autocomplete/autocomplete_target_users"')
+        expect(response.body).to include(%(name="record[user_id]"))
+        expect(response.body).to include(%(type="hidden"))
+        expect(response.body).to include(%(value="#{user.id}"))
+        expect(response.body).to include(%(type="text"))
+        expect(response.body).to include(%(value="#{user.email}"))
+        expect(response.body).not_to include(%(select name="record[user_id]"))
+      end
+    end
+  end
+
+  describe "belongs_to form associations" do
+    let(:tenant_scoped_license_resource) do
+      Class.new(IronAdmin::Resource) do
+        self.model_class_override = License
+
+        def self.name
+          "TenantScopedLicenseResource"
+        end
+
+        def self.resource_name
+          "tenant_scoped_licenses"
+        end
+
+        belongs_to :user, display: :email
+        form_fields :user
+      end
+    end
+
+    before do
+      IronAdmin::ResourceRegistry.register(tenant_scoped_license_resource)
+    end
+
+    after do
+      IronAdmin::ResourceRegistry.reset!
+      IronAdmin::ResourceRegistry.register(IronAdmin::Resources::UserResource)
+      IronAdmin::ResourceRegistry.register(IronAdmin::Resources::LicenseResource)
+    end
+
+    it "scopes belongs_to select options through the tenant scope" do
+      create(:user, email: "in-tenant@example.com", active: true)
+      create(:user, email: "outside-tenant@example.com", active: false)
+
+      IronAdmin.configure do |config|
+        config.tenant_scope do |scope|
+          scope.where(active: true)
+        end
+      end
+
+      get iron_admin.new_resource_path("tenant_scoped_licenses"), as: :html
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(%(name="record[user_id]"))
+      expect(response.body).to include("<select")
+      expect(response.body).to include("in-tenant@example.com")
+      expect(response.body).not_to include("outside-tenant@example.com")
+    end
   end
 
   describe "POST /:resource_name" do


### PR DESCRIPTION
Part of #98.

## Summary
- Render the existing belongs_to autocomplete component from the main form when `autocomplete: true` is configured.
- Preserve `record[foreign_key]`, selected id, selected label, and configured associated `resource:` for autocomplete URLs.
- Apply tenant scoping to non-autocomplete belongs_to select options instead of using raw `assoc_class.all`.

## Verification
- Targeted RED reproduced the missing configured-resource autocomplete URL.
- Targeted GREEN: `bundle exec rspec spec/requests/iron_admin/resources_spec.rb:1020 spec/requests/iron_admin/resources_spec.rb:1066` (2 examples, 0 failures; partial SimpleCov exit handled)
- `bundle exec rspec` (1958 examples, 0 failures, 96.69% coverage)
- `bundle exec rubocop` (291 files, no offenses)
- `git diff --check`
- SDD review: PASS/APPROVED, no findings

I will wait for GitHub checks/bot review and address any comments before merge.