### PR TITLE
Address Copilot review from PR 103

### DIFF
--- a/app/controllers/iron_admin/resources_controller.rb
+++ b/app/controllers/iron_admin/resources_controller.rb
@@ -294,7 +294,7 @@ module IronAdmin
       condition = action[:condition]
       return true unless condition
 
-      condition.arity.zero? ? record.instance_exec(&condition) : condition.call(record)
+      condition.call(record)
     end
 
     def prepare_action_record?(action)

--- a/lib/iron_admin/import/importer.rb
+++ b/lib/iron_admin/import/importer.rb
@@ -179,6 +179,7 @@ module IronAdmin
         lookup = attributes.slice(*keys)
         return nil unless lookup.size == keys.size && lookup.values.all?(&:present?)
 
+        # find_by_keys is an IronAdmin adapter hook, not an ActiveRecord dynamic finder.
         return adapter.find_by_keys(lookup) unless IronAdmin.configuration.tenant_scope_block # rubocop:disable Rails/DynamicFindBy
 
         scoped_existing_record(lookup)

--- a/spec/requests/iron_admin/action_forms_spec.rb
+++ b/spec/requests/iron_admin/action_forms_spec.rb
@@ -158,6 +158,58 @@ RSpec.describe "Action Forms", type: :request do
     end
   end
 
+  context "with an action condition that depends on its closure" do
+    let(:condition_owner) do
+      Object.new.tap do |owner|
+        owner.define_singleton_method(:allowed?) { false }
+      end
+    end
+    let(:closure_condition) { condition_owner.instance_eval { proc { allowed? } } }
+    let(:closure_condition_resource) do
+      condition = closure_condition
+
+      Class.new(IronAdmin::Resource) do
+        self.model_class_override = License
+
+        def self.name
+          "ClosureConditionResource"
+        end
+
+        def self.resource_name
+          "closure_condition_licenses"
+        end
+
+        belongs_to :user, display: :email
+
+        action :closure_guarded_action,
+               condition: condition,
+               form_fields: [
+                 action_field(:reason, type: :textarea),
+               ] do |lic, params|
+          lic.update!(license_type: params[:reason])
+        end
+      end
+    end
+
+    before { IronAdmin::ResourceRegistry.register(closure_condition_resource) }
+
+    it "uses the same condition call semantics as the show view on action forms" do
+      get iron_admin.resource_action_form_path("closure_condition_licenses", license, "closure_guarded_action"),
+          as: :html
+
+      expect(response).to have_http_status(:forbidden)
+    end
+
+    it "uses the same condition call semantics as the show view before executing" do
+      post iron_admin.resource_action_path("closure_condition_licenses", license, "closure_guarded_action"),
+           params: { action_form: { reason: "Changed" } },
+           as: :html
+
+      expect(response).to have_http_status(:forbidden)
+      expect(license.reload.license_type).to eq("standard")
+    end
+  end
+
   context "with 2-arg bulk_action block and form_fields" do
     let(:bulk_form_resource) do
       Class.new(IronAdmin::Resource) do

--- a/spec/requests/iron_admin/soft_delete_spec.rb
+++ b/spec/requests/iron_admin/soft_delete_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe "IronAdmin Soft Delete Integration", type: :request do
     end
   end
 
-  describe "direct restore routes when the action condition is false" do
+  context "when the action condition is false on direct restore routes" do
     let!(:active_post) { SoftDeletePost.create!(title: "Active Post", body: "Content") }
 
     it "forbids the restore action form" do


### PR DESCRIPTION
## Summary
- align direct action condition evaluation with show-view semantics
- add regression coverage for closure-backed action conditions
- address Copilot style/comment feedback from PR #103

## Verification
- bundle exec rspec spec/requests/iron_admin/action_forms_spec.rb:163 (2 examples, 0 failures; subset exit 2 due SimpleCov threshold)
- bundle exec rspec spec/requests/iron_admin/action_forms_spec.rb spec/requests/iron_admin/soft_delete_spec.rb spec/lib/iron_admin/import/importer_spec.rb (30 examples, 0 failures; subset exit 2 due SimpleCov threshold)
- bundle exec rspec (1969 examples, 0 failures, 96.71% coverage)
- bundle exec rubocop (291 files, no offenses)
- git diff --check

Follow-up to #103.