### PR TITLE
CI: gate gem publish on a published GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,20 @@ jobs:
           ruby-version: '3.2'
           bundler-cache: true
 
+      # Fail fast if the release tag and the gem version disagree. Without this,
+      # a mismatch (e.g. tag v0.6.0 while version.rb still says 0.5.0) builds the
+      # wrong gem and fails late at `gem push` with a confusing "repushing not
+      # allowed" — exactly the failure that broke the first 0.6.0 publish.
+      - name: Verify tag matches gem version
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          GEM_VERSION="$(ruby -r ./lib/iron_admin/version -e 'print IronAdmin::VERSION')"
+          if [ "$TAG_VERSION" != "$GEM_VERSION" ]; then
+            echo "::error::Release tag v${TAG_VERSION} does not match gem version ${GEM_VERSION} in lib/iron_admin/version.rb. Bump version.rb (and Gemfile.lock) to match before publishing the Release."
+            exit 1
+          fi
+          echo "Tag v${TAG_VERSION} matches gem version ${GEM_VERSION}"
+
       - name: Build gem
         run: gem build iron_admin.gemspec
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,18 @@
 name: Release Gem
 
+# Publishing is gated on a GitHub Release. Pushing a bare tag does NOT publish
+# anything — only *publishing a GitHub Release* fires this workflow, which then
+# tests, builds, and pushes the gem to RubyGems via trusted publishing (OIDC).
+# See RELEASING.md for the full runbook.
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -29,9 +32,16 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    # Declaring an environment records a deployment that turns GREEN on success
+    # and shows in the repo's Deployments sidebar. The OIDC token now carries an
+    # `environment: release` claim, but the RubyGems trusted publisher has no
+    # environment configured, so that claim is ignored and publishing still works.
+    environment:
+      name: release
+      url: https://rubygems.org/gems/iron_admin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,62 @@
+# Releasing IronAdmin
+
+Publishing to RubyGems is **gated on a GitHub Release**. Pushing a bare git tag
+does **not** publish anything — only *publishing a GitHub Release* triggers
+[`.github/workflows/release.yml`](.github/workflows/release.yml), which then:
+
+1. runs the test suite (`rspec`) and the linter (`rubocop`),
+2. builds `iron_admin-X.Y.Z.gem`,
+3. pushes it to RubyGems via **trusted publishing** (OIDC — no API key or secret
+   is stored anywhere; GitHub Actions proves its identity to RubyGems and
+   RubyGems, configured to trust this repo's `release.yml`, accepts the push),
+4. records a **green deployment** to the `release` environment.
+
+## How a release happens
+
+### 1. Prepare the release PR (never commit to `main` directly)
+
+On a feature branch:
+
+- Bump `lib/iron_admin/version.rb` to the new version (e.g. `0.7.0`). Run
+  `bundle install` so `Gemfile.lock` picks up the new version.
+- In `CHANGELOG.md`: move the `[Unreleased]` entries under a new
+  `## [0.7.0] - YYYY-MM-DD` heading, reopen an empty `[Unreleased]`, and add the
+  `[0.7.0]: .../compare/v0.6.0...v0.7.0` reference link at the bottom.
+- If there are breaking changes, update `UPGRADING.md`.
+
+Open the PR, let CI and the Copilot review pass, then merge to `main`.
+
+> The gem version comes from `version.rb`, **not** from the tag name. Make sure
+> they match before publishing the Release. (A mismatch is exactly what broke the
+> first 0.6.0 attempt: the tag said `v0.6.0` but `version.rb` still said `0.5.0`,
+> so CI rebuilt `0.5.0` and RubyGems rejected the duplicate.)
+
+### 2. Publish the GitHub Release — this is the deliberate "go"
+
+From an up-to-date `main` (with `version.rb` already at the new version):
+
+```bash
+gh release create v0.7.0 \
+  --target main \
+  --title v0.7.0 \
+  --notes-file <(awk '/^## \[0\.7\.0\]/{f=1;next} f&&/^## \[/{exit} f' CHANGELOG.md) \
+  --latest
+```
+
+The `awk` snippet pulls the `## [0.7.0]` section out of `CHANGELOG.md` for the
+release notes. You can also do this from the GitHub UI:
+**Releases → Draft a new release → tag `v0.7.0` → paste notes → Publish**.
+
+Publishing the Release creates the tag and fires `release.yml`. The gem is
+published automatically a minute later, and the `release` deployment turns green.
+
+## Notes & gotchas
+
+- **Never run `rake release` locally** — it would `gem push` a second time.
+- A bare `git push origin v0.7.0` will **not** publish. Only a *published*
+  GitHub Release does.
+- **No secrets needed.** Publishing authenticates from GitHub Actions to RubyGems
+  via OIDC trusted publishing.
+- One-time setup to verify (see the release PR for details): the RubyGems trusted
+  publisher's *Environment* field must be blank or exactly `release`, and the
+  GitHub `release` environment must have no blocking protection rules.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -29,7 +29,9 @@ Open the PR, let CI and the Copilot review pass, then merge to `main`.
 > The gem version comes from `version.rb`, **not** from the tag name. Make sure
 > they match before publishing the Release. (A mismatch is exactly what broke the
 > first 0.6.0 attempt: the tag said `v0.6.0` but `version.rb` still said `0.5.0`,
-> so CI rebuilt `0.5.0` and RubyGems rejected the duplicate.)
+> so CI rebuilt `0.5.0` and RubyGems rejected the duplicate.) The workflow now
+> guards against this: a **Verify tag matches gem version** step fails the release
+> fast with a clear error if the tag and `version.rb` diverge.
 
 ### 2. Publish the GitHub Release — this is the deliberate "go"
 


### PR DESCRIPTION
## What

Makes the RubyGems publish **gated on a published GitHub Release** instead of on a bare tag push, and makes the publish show a **green deployment**. This is the flow you asked for so the next release (v0.7.0) is deliberate and visible.

### New flow (documented in `RELEASING.md`)
1. Bump `version.rb` + `CHANGELOG.md` on a branch → PR → merge to `main` (**nothing publishes**).
2. **Publish a GitHub Release** for the version — UI button or `gh release create` (this is the deliberate "go").
3. That fires `release.yml` → test → build → `gem push` (OIDC trusted publishing) → **green deployment** to the `release` environment.

> A bare `git push origin vX.Y.Z` no longer publishes anything — only a *published* GitHub Release does.

## Changes
- **`release.yml`**: trigger `on: release: published` (was `on: push: tags`).
- **`release.yml`**: add `environment: release` (+ `url`) on the release job → green deployment in the sidebar.
- **`release.yml`**: bump `actions/checkout@v4 → @v5` (clears the Node 20 deprecation warning seen in recent runs).
- **`RELEASING.md`**: new release runbook.

## Why it's safe for trusted publishing
RubyGems trusted publishing (mirroring PyPI) only verifies the OIDC `environment` claim **if an environment is configured on the publisher**. The `iron_admin` publisher has that field blank, so adding `environment: release` is silently ignored and the publish keeps working. Refs: [RubyGems trusted-publishing guide](https://guides.rubygems.org/trusted-publishing/), [pypi/warehouse#17241](https://github.com/pypi/warehouse/issues/17241).

## ⚠️ One-time manual checks before the next release
1. **RubyGems.org → `iron_admin` → Trusted publishers:** confirm the GitHub Actions publisher's **Environment** field is **blank** (or exactly `release`). Any other value would break `gem push`.
2. **GitHub repo → Settings → Environments → `release`:** confirm there are **no required reviewers / wait timer / branch-tag rules** that would pause the publish (the env was auto-created by the old failed v0.4.1 run and likely has none).
3. Optional cleanup: delete the stale red v0.4.1 deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)