### PR TITLE
Expand dashboard chart types and add a progress widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Expanded dashboard chart types** — The `chart` DSL now supports four new types in addition to `:line`, `:bar`, `:pie`, and `:doughnut`:
-  - `:area` — filled line chart that emphasizes volume over time
+  - `:area` — explicit, intention-revealing name for a filled line chart (`:line` remains filled for backward compatibility)
   - `:horizontal_bar` — bar chart with the category axis on the y-axis (great for long labels)
   - `:radar` — radar/spider chart for multivariate comparisons
   - `:polar_area` — polar area chart for proportions with magnitude
   - IronAdmin types map to the correct Chart.js primitives internally (`:area`/`:horizontal_bar`/`:polar_area` → `line`/`bar` with `indexAxis: y`/`polarArea`).
 - **Progress (gauge) dashboard widget** — New `progress` DSL primitive renders a value as a proportion of a target, with the value, target, and percentage displayed as a horizontal bar. Supports `max:`, `format:` (`:number`/`:currency`/`:percentage`), `label:`, and a per-widget `color:` (defaults to the theme chart border color). Rendered by the new `IronAdmin::Dashboards::ProgressComponent`.
-
-### Changed
-
-- **`:line` charts are no longer filled by default.** A plain `:line` chart now renders an unfilled trend line; use the new `:area` type for the previous filled-line appearance.
 
 ## [0.6.0] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Expanded dashboard chart types** — The `chart` DSL now supports four new types in addition to `:line`, `:bar`, `:pie`, and `:doughnut`:
+  - `:area` — filled line chart that emphasizes volume over time
+  - `:horizontal_bar` — bar chart with the category axis on the y-axis (great for long labels)
+  - `:radar` — radar/spider chart for multivariate comparisons
+  - `:polar_area` — polar area chart for proportions with magnitude
+  - IronAdmin types map to the correct Chart.js primitives internally (`:area`/`:horizontal_bar`/`:polar_area` → `line`/`bar` with `indexAxis: y`/`polarArea`).
+- **Progress (gauge) dashboard widget** — New `progress` DSL primitive renders a value as a proportion of a target, with the value, target, and percentage displayed as a horizontal bar. Supports `max:`, `format:` (`:number`/`:currency`/`:percentage`), `label:`, and a per-widget `color:` (defaults to the theme chart border color). Rendered by the new `IronAdmin::Dashboards::ProgressComponent`.
+
+### Changed
+
+- **`:line` charts are no longer filled by default.** A plain `:line` chart now renders an unfilled trend line; use the new `:area` type for the previous filled-line appearance.
+
 ## [0.6.0] - 2026-06-28
 
 > ⚠️ **Upgrading from 0.5.0?** Plain ActiveRecord applications need no code changes, but this release carries **breaking changes** for code that touches IronAdmin internals or maintains a custom adapter. Read the [Breaking changes](#breaking-changes) section below and the [0.6.0 upgrade guide](UPGRADING.md) before upgrading.

--- a/app/components/iron_admin/dashboards/chart_component.rb
+++ b/app/components/iron_admin/dashboards/chart_component.rb
@@ -8,7 +8,8 @@ module IronAdmin
       # @return [String] Chart title
       attr_reader :title
 
-      # @return [Symbol] Chart type (:line, :bar, :pie, :doughnut)
+      # @return [Symbol] Chart type
+      #   (:line, :area, :bar, :horizontal_bar, :pie, :doughnut, :radar, :polar_area)
       attr_reader :type
 
       # @return [Array] Chart data
@@ -22,7 +23,25 @@ module IronAdmin
 
       # Supported chart types.
       # @return [Array<Symbol>]
-      TYPES = %i[line bar pie doughnut].freeze
+      TYPES = %i[line area bar horizontal_bar pie doughnut radar polar_area].freeze
+
+      # Maps IronAdmin chart types to their underlying Chart.js type strings.
+      # Types not listed here map to themselves.
+      # @return [Hash{Symbol=>Symbol}]
+      CHART_JS_TYPES = { area: :line, horizontal_bar: :bar, polar_area: :polarArea }.freeze
+
+      # Single-series types that render one line/shape with a border color and a
+      # semi-transparent fill, rather than a per-slice color palette.
+      # @return [Array<Symbol>]
+      SINGLE_SERIES_TYPES = %i[line area radar].freeze
+
+      # Types whose area is filled by default.
+      # @return [Array<Symbol>]
+      FILLED_TYPES = %i[area radar].freeze
+
+      # Types that display a legend (multi-slice proportion charts).
+      # @return [Array<Symbol>]
+      LEGEND_TYPES = %i[pie doughnut polar_area].freeze
 
       # @param title [String] Chart title
       # @param type [Symbol] Chart type (default: :line)
@@ -54,28 +73,52 @@ module IronAdmin
       # @api private
       # @return [String] Chart.js configuration JSON
       def chart_config
-        colors = resolved_colors
         border = resolved_border_color
         {
-          type: type,
+          type: chart_js_type,
           data: {
             labels: labels,
             datasets: [{
               data: data,
               borderColor: border,
-              backgroundColor: type == :line ? line_fill_color(border) : colors,
-              fill: type == :line,
+              backgroundColor: dataset_background(border),
+              fill: filled?,
               tension: 0.3,
             }],
           },
           options: {
             responsive: true,
             maintainAspectRatio: false,
+            indexAxis: index_axis,
             plugins: {
-              legend: { display: %i[pie doughnut].include?(type) },
+              legend: { display: legend? },
             },
           },
         }.to_json
+      end
+
+      # @api private
+      # @return [Symbol] Underlying Chart.js type string for this chart type
+      def chart_js_type
+        CHART_JS_TYPES.fetch(type, type)
+      end
+
+      # @api private
+      # @return [Boolean] Whether the dataset area is filled
+      def filled?
+        FILLED_TYPES.include?(type)
+      end
+
+      # @api private
+      # @return [Boolean] Whether a legend is displayed for this chart type
+      def legend?
+        LEGEND_TYPES.include?(type)
+      end
+
+      # @api private
+      # @return [String] Primary axis ("y" for horizontal bars, otherwise "x")
+      def index_axis
+        type == :horizontal_bar ? "y" : "x"
       end
 
       # Resolves chart colors with priority: per-chart > theme > default.
@@ -86,6 +129,14 @@ module IronAdmin
       end
 
       private
+
+      # Resolves the dataset background: a single semi-transparent fill for
+      # single-series charts, or the full color palette for multi-slice charts.
+      # @param border [String] Resolved border color
+      # @return [String, Array<String>] Background color(s) for the dataset
+      def dataset_background(border)
+        SINGLE_SERIES_TYPES.include?(type) ? line_fill_color(border) : resolved_colors
+      end
 
       # @return [Array<String>] Color palette resolved from per-chart, theme, or default
       def resolved_colors

--- a/app/components/iron_admin/dashboards/chart_component.rb
+++ b/app/components/iron_admin/dashboards/chart_component.rb
@@ -35,9 +35,11 @@ module IronAdmin
       # @return [Array<Symbol>]
       SINGLE_SERIES_TYPES = %i[line area radar].freeze
 
-      # Types whose area is filled by default.
+      # Types whose area is filled by default. `:line` stays filled for
+      # backward compatibility (it was filled before `:area` was introduced);
+      # `:area` is the explicit, intention-revealing name for a filled line.
       # @return [Array<Symbol>]
-      FILLED_TYPES = %i[area radar].freeze
+      FILLED_TYPES = %i[line area radar].freeze
 
       # Types that display a legend (multi-slice proportion charts).
       # @return [Array<Symbol>]

--- a/app/components/iron_admin/dashboards/progress_component.html.haml
+++ b/app/components/iron_admin/dashboards/progress_component.html.haml
@@ -1,0 +1,7 @@
+%div{ class: "#{theme.card_bg} border #{theme.card_border} #{theme.border_radius} #{theme.card_shadow} p-6" }
+  .flex.items-center.justify-between.mb-2
+    %h3.text-sm.font-medium{ class: theme.muted_text }= title
+    %span.text-sm.font-semibold{ class: theme.body_text }= "#{formatted_value} / #{formatted_max}"
+  .w-full.bg-gray-200.rounded-full.h-2.5
+    %div{ class: "h-2.5 rounded-full", style: "width: #{percentage}%; background-color: #{bar_color};" }
+  %p.mt-2.text-xs.text-right{ class: theme.muted_text }= "#{percentage}%"

--- a/app/components/iron_admin/dashboards/progress_component.rb
+++ b/app/components/iron_admin/dashboards/progress_component.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module IronAdmin
+  module Dashboards
+    # Renders a progress (gauge) widget showing a value as a proportion of a target.
+    class ProgressComponent < ViewComponent::Base
+      # @return [String] Widget title
+      attr_reader :title
+
+      # @return [Float] Current value
+      attr_reader :value
+
+      # @return [Float] Target/maximum value
+      attr_reader :max
+
+      # @return [Symbol] Value format (:number, :currency, :percentage)
+      attr_reader :format
+
+      # @param title [String] Widget title
+      # @param value [Numeric] Current value
+      # @param max [Numeric] Target/maximum value (default: 100)
+      # @param format [Symbol] Value format (default: :number)
+      # @param color [String, nil] CSS color for the filled bar (overrides theme)
+      def initialize(title:, value:, max: 100, format: :number, color: nil)
+        @title = title
+        @value = value.to_f
+        @max = max.to_f
+        @format = format
+        @color = color
+      end
+
+      # @api private
+      # @return [Float] Completion percentage clamped to 0..100
+      def percentage
+        return 0.0 if max.zero?
+
+        ((value / max) * 100).clamp(0, 100).round(1)
+      end
+
+      # @api private
+      # @return [String] Current value formatted according to format option
+      def formatted_value
+        format_number(value)
+      end
+
+      # @api private
+      # @return [String] Target value formatted according to format option
+      def formatted_max
+        format_number(max)
+      end
+
+      # @api private
+      # @return [String] CSS color for the filled bar
+      def bar_color
+        @color || theme.chart_border_color
+      end
+
+      # @api private
+      # @return [IronAdmin::Configuration::Theme] Theme configuration
+      def theme
+        IronAdmin.configuration.theme
+      end
+
+      private
+
+      # @param number [Numeric] The value to format
+      # @return [String] Formatted value
+      def format_number(number)
+        case format
+        when :currency then helpers.number_to_currency(number)
+        when :percentage then helpers.number_to_percentage(number, precision: 1)
+        else helpers.number_with_delimiter(number.to_i == number ? number.to_i : number)
+        end
+      end
+    end
+  end
+end

--- a/app/views/iron_admin/dashboard/index.html.haml
+++ b/app/views/iron_admin/dashboard/index.html.haml
@@ -21,6 +21,12 @@
           - else
             = render IronAdmin::Dashboards::ChartComponent.new(title: chart_title, type: chart[:type], data: data, labels: labels, colors: chart[:colors])
 
+    - if @dashboard.defined_progress_bars.any?
+      .grid.grid-cols-1.md:grid-cols-2.lg:grid-cols-3.gap-6.mb-8
+        - @dashboard.defined_progress_bars.each do |bar|
+          - bar_title = bar[:label] || bar[:name].to_s.humanize
+          = render IronAdmin::Dashboards::ProgressComponent.new(title: bar_title, value: bar[:block].call, max: bar[:max], format: bar[:format], color: bar[:color])
+
     - if @dashboard.defined_recents.any?
       .space-y-6
         - @dashboard.defined_recents.each do |recent|

--- a/lib/iron_admin/dashboard.rb
+++ b/lib/iron_admin/dashboard.rb
@@ -46,6 +46,7 @@ module IronAdmin
     class_attribute :defined_metrics, default: []
     class_attribute :defined_charts, default: []
     class_attribute :defined_recents, default: []
+    class_attribute :defined_progress_bars, default: []
     class_attribute :_layout_block, default: nil
 
     class << self
@@ -93,9 +94,13 @@ module IronAdmin
       # @param name [Symbol] The chart identifier
       # @param type [Symbol] The chart type
       #   - :line - Line chart for trends over time
-      #   - :bar - Bar chart for comparisons
+      #   - :area - Filled line chart, emphasizes volume over time
+      #   - :bar - Vertical bar chart for comparisons
+      #   - :horizontal_bar - Horizontal bar chart, good for long category labels
       #   - :pie - Pie chart for proportions
       #   - :doughnut - Doughnut chart for proportions
+      #   - :radar - Radar chart for multivariate comparisons
+      #   - :polar_area - Polar area chart for proportions with magnitude
       # @param colors [Array<String>, nil] Optional per-chart color palette (CSS color values).
       #   Overrides the global theme chart_colors for this chart.
       # @param label [String, nil] Custom display title for the chart.
@@ -117,6 +122,41 @@ module IronAdmin
       def chart(name, type: :line, colors: nil, label: nil, live: false, &block)
         self.defined_charts = defined_charts + [
           { name: name, type: type, colors: colors, label: label, live: live, block: block },
+        ]
+      end
+
+      # Defines a progress (gauge) widget for the dashboard.
+      #
+      # Progress widgets show a single value as a proportion of a target,
+      # rendered as a horizontal bar with the value, target, and percentage.
+      # They're useful for goals, quotas, capacity, and completion rates.
+      #
+      # @param name [Symbol] The widget identifier (used as the label)
+      # @param max [Numeric] The target/maximum value the bar fills toward (default: 100)
+      # @param format [Symbol] How to format the value and target
+      #   - :number - Plain number with thousands separators
+      #   - :currency - Currency format (uses Rails number_to_currency)
+      #   - :percentage - Percentage format
+      # @param label [String, nil] Custom display title. Defaults to `name.to_s.humanize`.
+      # @param color [String, nil] Optional CSS color for the filled bar.
+      #   Defaults to the theme chart border color.
+      # @yield Block that computes and returns the current value
+      # @yieldreturn [Numeric] The current value
+      #
+      # @example Monthly signups toward a goal
+      #   progress :monthly_signups, max: 500 do
+      #     User.where(created_at: Time.current.all_month).count
+      #   end
+      #
+      # @example Revenue goal with currency formatting
+      #   progress :revenue_goal, max: 100_000, format: :currency, label: "Revenue Goal" do
+      #     Order.this_month.sum(:total)
+      #   end
+      #
+      # @return [void]
+      def progress(name, max: 100, format: :number, label: nil, color: nil, &block)
+        self.defined_progress_bars = defined_progress_bars + [
+          { name: name, max: max, format: format, label: label, color: color, block: block },
         ]
       end
 

--- a/spec/components/iron_admin/dashboards/chart_component_spec.rb
+++ b/spec/components/iron_admin/dashboards/chart_component_spec.rb
@@ -84,6 +84,66 @@ RSpec.describe IronAdmin::Dashboards::ChartComponent, type: :component do
       end
     end
 
+    context "with an area chart" do
+      subject(:config) { JSON.parse(described_class.new(title: "Volume", type: :area, data: [1], labels: ["A"]).chart_config) }
+
+      it "renders as a line chart in Chart.js" do
+        expect(config["type"]).to eq("line")
+      end
+
+      it "fills the dataset" do
+        expect(config["data"]["datasets"].first["fill"]).to be(true)
+      end
+    end
+
+    context "with a line chart" do
+      subject(:config) { JSON.parse(described_class.new(title: "Trend", type: :line, data: [1], labels: ["A"]).chart_config) }
+
+      it "does not fill the dataset" do
+        expect(config["data"]["datasets"].first["fill"]).to be(false)
+      end
+    end
+
+    context "with a horizontal bar chart" do
+      subject(:config) { JSON.parse(described_class.new(title: "Ranking", type: :horizontal_bar, data: [1], labels: ["A"]).chart_config) }
+
+      it "renders as a bar chart in Chart.js" do
+        expect(config["type"]).to eq("bar")
+      end
+
+      it "sets the primary axis to y" do
+        expect(config["options"]["indexAxis"]).to eq("y")
+      end
+    end
+
+    context "with a radar chart" do
+      subject(:config) { JSON.parse(described_class.new(title: "Skills", type: :radar, data: [1], labels: ["A"]).chart_config) }
+
+      it "keeps the radar type" do
+        expect(config["type"]).to eq("radar")
+      end
+
+      it "fills the dataset" do
+        expect(config["data"]["datasets"].first["fill"]).to be(true)
+      end
+    end
+
+    context "with a polar area chart" do
+      subject(:config) { JSON.parse(described_class.new(title: "Split", type: :polar_area, data: [1, 2], labels: %w[A B], colors: ["#111", "#222"]).chart_config) }
+
+      it "maps to the polarArea Chart.js type" do
+        expect(config["type"]).to eq("polarArea")
+      end
+
+      it "displays a legend" do
+        expect(config["options"]["plugins"]["legend"]["display"]).to be(true)
+      end
+
+      it "uses the color palette as backgroundColor" do
+        expect(config["data"]["datasets"].first["backgroundColor"]).to eq(["#111", "#222"])
+      end
+    end
+
     context "with theme border color" do
       before do
         IronAdmin.configuration.theme.chart_border_color = "rgb(34, 197, 94)"

--- a/spec/components/iron_admin/dashboards/chart_component_spec.rb
+++ b/spec/components/iron_admin/dashboards/chart_component_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe IronAdmin::Dashboards::ChartComponent, type: :component do
     context "with a line chart" do
       subject(:config) { JSON.parse(described_class.new(title: "Trend", type: :line, data: [1], labels: ["A"]).chart_config) }
 
-      it "does not fill the dataset" do
-        expect(config["data"]["datasets"].first["fill"]).to be(false)
+      it "fills the dataset (backward compatible with pre-:area behavior)" do
+        expect(config["data"]["datasets"].first["fill"]).to be(true)
       end
     end
 

--- a/spec/components/iron_admin/dashboards/progress_component_spec.rb
+++ b/spec/components/iron_admin/dashboards/progress_component_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+require_relative "../../../../app/components/iron_admin/dashboards/progress_component"
+
+RSpec.describe IronAdmin::Dashboards::ProgressComponent, type: :component do
+  describe "#initialize" do
+    subject(:component) { described_class.new(title: "Signups", value: 40, max: 200) }
+
+    it "requires a title" do
+      expect(component.title).to eq("Signups")
+    end
+
+    it "coerces value to a float" do
+      expect(component.value).to eq(40.0)
+    end
+
+    it "coerces max to a float" do
+      expect(component.max).to eq(200.0)
+    end
+
+    it "defaults max to 100" do
+      expect(described_class.new(title: "Signups", value: 40).max).to eq(100.0)
+    end
+
+    it "defaults format to number" do
+      expect(described_class.new(title: "Signups", value: 40).format).to eq(:number)
+    end
+  end
+
+  describe "#percentage" do
+    it "computes the completion ratio" do
+      component = described_class.new(title: "Goal", value: 25, max: 100)
+      expect(component.percentage).to eq(25.0)
+    end
+
+    it "clamps values above the max to 100" do
+      component = described_class.new(title: "Goal", value: 150, max: 100)
+      expect(component.percentage).to eq(100.0)
+    end
+
+    context "when max is zero" do
+      it "returns zero instead of dividing by zero" do
+        component = described_class.new(title: "Goal", value: 5, max: 0)
+        expect(component.percentage).to eq(0.0)
+      end
+    end
+  end
+
+  describe "#bar_color" do
+    context "without a custom color" do
+      it "falls back to the theme border color" do
+        component = described_class.new(title: "Goal", value: 5)
+        expect(component.bar_color).to eq(IronAdmin.configuration.theme.chart_border_color)
+      end
+    end
+
+    context "with a custom color" do
+      it "uses the provided color" do
+        component = described_class.new(title: "Goal", value: 5, color: "#10b981")
+        expect(component.bar_color).to eq("#10b981")
+      end
+    end
+  end
+
+  describe "rendering" do
+    it "renders the title" do
+      result = render_inline(described_class.new(title: "Signups", value: 50, max: 100))
+      expect(result.text).to include("Signups")
+    end
+
+    it "renders the completion percentage" do
+      result = render_inline(described_class.new(title: "Signups", value: 25, max: 100))
+      expect(result.text).to include("25.0%")
+    end
+
+    it "formats currency values" do
+      result = render_inline(described_class.new(title: "Revenue", value: 1500, max: 5000, format: :currency))
+      expect(result.text).to include("$1,500.00")
+    end
+
+    it "fills the bar to the computed width" do
+      result = render_inline(described_class.new(title: "Goal", value: 25, max: 100))
+      expect(result.to_html).to include("width: 25.0%")
+    end
+  end
+end

--- a/spec/lib/iron_admin/dashboard_spec.rb
+++ b/spec/lib/iron_admin/dashboard_spec.rb
@@ -123,4 +123,52 @@ RSpec.describe IronAdmin::Dashboard do
       expect(TestDashboard.defined_recents.first[:limit]).to eq(5)
     end
   end
+
+  describe "progress bars" do
+    subject(:dashboard_class) do
+      Class.new(IronAdmin::Dashboard) do
+        progress :signups_goal, max: 500, label: "Signups Goal", color: "#10b981" do
+          120
+        end
+      end
+    end
+
+    it "stores progress definitions" do
+      expect(dashboard_class.defined_progress_bars.length).to eq(1)
+    end
+
+    it "evaluates the value block" do
+      expect(dashboard_class.defined_progress_bars.first[:block].call).to eq(120)
+    end
+
+    it "stores the max target" do
+      expect(dashboard_class.defined_progress_bars.first[:max]).to eq(500)
+    end
+
+    it "stores the label" do
+      expect(dashboard_class.defined_progress_bars.first[:label]).to eq("Signups Goal")
+    end
+
+    it "stores the color" do
+      expect(dashboard_class.defined_progress_bars.first[:color]).to eq("#10b981")
+    end
+
+    context "with defaults" do
+      subject(:dashboard_class) do
+        Class.new(IronAdmin::Dashboard) do
+          progress :capacity do
+            10
+          end
+        end
+      end
+
+      it "defaults max to 100" do
+        expect(dashboard_class.defined_progress_bars.first[:max]).to eq(100)
+      end
+
+      it "defaults format to number" do
+        expect(dashboard_class.defined_progress_bars.first[:format]).to eq(:number)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #107.

Extends the dashboard `chart`/widget DSL on top of the existing ViewComponent + Chart.js stack.

## What's new
- **Chart types:** `:area`, `:horizontal_bar`, `:radar`, `:polar_area` (mapped to the right Chart.js primitives internally). `chart_config` was refactored into small helpers driven by frozen constants.
- **Progress (gauge) widget:** `progress :name, max:, format:, label:, color: do ... end` → new `ProgressComponent` rendering value/target and a percentage bar. Supports `:number`/`:currency`/`:percentage`.

## Backward compatibility
`:line` **stays filled by default** — no change to existing dashboards. `:area` is the additive, explicit name for a filled line. Fully additive, no public-DSL breaking changes.

## Out of scope
- `:scatter`/`:bubble` (need `{x, y}` data, doesn't fit the current `label => value` contract).

## Follow-up
- Theme token for the progress track color/height (currently `bg-gray-200`).

## Verification
- `bundle exec rspec` → **2000 examples, 0 failures**
- `bundle exec rubocop` → **0 offenses**

🤖 Generated with [Claude Code](https://claude.com/claude-code)