### PR TITLE
Plugin / community extension system (design + experimental PoC)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `:polar_area` — polar area chart for proportions with magnitude
   - IronAdmin types map to the correct Chart.js primitives internally (`:area`/`:horizontal_bar`/`:polar_area` → `line`/`bar` with `indexAxis: y`/`polarArea`).
 - **Progress (gauge) dashboard widget** — New `progress` DSL primitive renders a value as a proportion of a target, with the value, target, and percentage displayed as a horizontal bar. Supports `max:`, `format:` (`:number`/`:currency`/`:percentage`), `label:`, and a per-widget `color:` (defaults to the theme chart border color). Rendered by the new `IronAdmin::Dashboards::ProgressComponent`.
-- **Plugin / community extension system (proof of concept)** — foundation for packaging IronAdmin extensions as redistributable gems:
+- **Plugin / community extension system (experimental, proof of concept)** — foundation for packaging IronAdmin extensions as redistributable gems. ⚠️ **This API is experimental and unstable until 1.0** — it is not covered by the zero-breaking-changes invariant and may change or be removed before general availability.
   - `IronAdmin::Plugin` base class with a declarative DSL (`plugin_name`, `plugin_version`, `requires_iron_admin`) and a `setup` block.
   - `IronAdmin.register_plugin` / `IronAdmin::PluginRegistry` — explicit, idempotent registration and activation (re-activated on engine reload).
-  - `IronAdmin::Plugin::Registration` facade — the stable plugin API surface — with three working extension points: custom sidebar `menu_item`s, global `component` overrides, and `field_type` registration.
+  - `IronAdmin::Plugin::Registration` facade — the (experimental) plugin API surface — with three working extension points: custom sidebar `menu_item`s, global `component` overrides, and `field_type` registration.
   - `IronAdmin::MenuItem` + `IronAdmin::MenuRegistry` — new sidebar extension point for custom navigation links that are not resource/tool-derived.
   - Version-compatibility enforcement via `IronAdmin::IncompatiblePluginError` (and `IronAdmin::PluginError`).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `:polar_area` — polar area chart for proportions with magnitude
   - IronAdmin types map to the correct Chart.js primitives internally (`:area`/`:horizontal_bar`/`:polar_area` → `line`/`bar` with `indexAxis: y`/`polarArea`).
 - **Progress (gauge) dashboard widget** — New `progress` DSL primitive renders a value as a proportion of a target, with the value, target, and percentage displayed as a horizontal bar. Supports `max:`, `format:` (`:number`/`:currency`/`:percentage`), `label:`, and a per-widget `color:` (defaults to the theme chart border color). Rendered by the new `IronAdmin::Dashboards::ProgressComponent`.
+- **Plugin / community extension system (proof of concept)** — foundation for packaging IronAdmin extensions as redistributable gems:
+  - `IronAdmin::Plugin` base class with a declarative DSL (`plugin_name`, `plugin_version`, `requires_iron_admin`) and a `setup` block.
+  - `IronAdmin.register_plugin` / `IronAdmin::PluginRegistry` — explicit, idempotent registration and activation (re-activated on engine reload).
+  - `IronAdmin::Plugin::Registration` facade — the stable plugin API surface — with three working extension points: custom sidebar `menu_item`s, global `component` overrides, and `field_type` registration.
+  - `IronAdmin::MenuItem` + `IronAdmin::MenuRegistry` — new sidebar extension point for custom navigation links that are not resource/tool-derived.
+  - Version-compatibility enforcement via `IronAdmin::IncompatiblePluginError` (and `IronAdmin::PluginError`).
+
+### Documentation
+
+- Added `docs/plugin-system-design.md` — full design proposal for the plugin/community extension system: philosophy, extension points, packaging model, registration API, versioning/security considerations, an end-to-end example, and the deferred work + decisions requiring maintainer sign-off.
 
 ## [0.6.0] - 2026-06-28
 

--- a/docs/plugin-system-design.md
+++ b/docs/plugin-system-design.md
@@ -5,6 +5,13 @@
 > remaining extension points are specified here but not yet built. This
 > document is the contract a maintainer should approve before the feature is
 > completed.
+>
+> ⚠️ **Stability: EXPERIMENTAL / unstable until 1.0.** The public surface
+> described here (`IronAdmin.register_plugin`, `IronAdmin::Plugin`,
+> `Plugin::Registration`, `MenuItem`/`MenuRegistry`) is **not** covered by the
+> project's zero-breaking-changes invariant and may change or be removed
+> before general availability. It becomes semver-governed only when the plugin
+> system reaches GA (targeted for 1.0).
 
 ## 1. Philosophy — what a plugin is (and is not)
 

--- a/docs/plugin-system-design.md
+++ b/docs/plugin-system-design.md
@@ -1,0 +1,373 @@
+# Plugin / Community Extension System — Design Proposal
+
+> Status: **Design proposal + proof-of-concept skeleton.** The registration
+> core and two-and-a-half extension points are implemented and tested; the
+> remaining extension points are specified here but not yet built. This
+> document is the contract a maintainer should approve before the feature is
+> completed.
+
+## 1. Philosophy — what a plugin is (and is not)
+
+IronAdmin is already, quietly, an extensible system. Resources and tools
+self-register via an `inherited` hook, dashboards self-register, field types
+register through `IronAdmin.register_field_type`, components are swappable
+through `config.components`, and adapters resolve through a registry. Host
+applications extend IronAdmin every day just by dropping files into
+`app/iron_admin/`.
+
+A **plugin** is the packaging of those same extension points into a
+**redistributable Rails gem** so that *one* author can ship a coherent bundle
+of admin functionality that *many* host apps install with a single line.
+
+**A plugin IS:**
+
+- A normal Rails gem that `require`s IronAdmin and calls a small, stable
+  registration API.
+- A bundle of one or more extensions: resources, dashboards, tools, field
+  types, adapters, component overrides, and custom menu entries.
+- Versioned and declared-compatible against an IronAdmin version range.
+- Activated **explicitly** by the host (`IronAdmin.register_plugin`) — the host
+  keeps an auditable list of everything extending its admin panel.
+
+**A plugin IS NOT:**
+
+- A sandbox or a security boundary. A plugin is arbitrary Ruby loaded into the
+  host process with full application privileges (see §6). Installing a plugin
+  is exactly as much a trust decision as adding any gem to the `Gemfile`.
+- A runtime-togglable module. Plugins are wired at boot, not enabled/disabled
+  per request.
+- A replacement for the existing `app/iron_admin/` convention. Host-owned
+  resources still live there; plugins are for *shareable, cross-app* bundles.
+
+### Design principle: a facade, not raw registries
+
+Plugins never touch `ResourceRegistry`, `ToolRegistry`, `FieldTypeRegistry`,
+`Configuration`, etc. directly. They receive a **`Registration` facade**
+(§4) whose surface is the public plugin API. Internal registries can be
+refactored freely as long as the facade holds. This is the single most
+important architectural commitment in this proposal.
+
+## 2. Extension points
+
+The table maps each extension point to the existing IronAdmin mechanism it
+builds on, and its status in this proposal.
+
+| Extension point   | Underlying mechanism today                          | Status in skeleton |
+|-------------------|-----------------------------------------------------|--------------------|
+| Menu items        | *(new)* — sidebar was resource/tool-derived only    | **Implemented**    |
+| Component override | `config.components.<slot> = Klass`                  | **Implemented**    |
+| Field types       | `FieldTypeRegistry.register` / `register_field_type`| **Implemented**    |
+| Resources         | `inherited` → `ResourceRegistry`, Zeitwerk `push_dir`| Design only        |
+| Dashboards        | `inherited` → `IronAdmin.dashboard_class`           | Design only        |
+| Tools             | `inherited` → `ToolRegistry`                         | Design only        |
+| Adapters          | `Adapters::Registry::ADAPTERS` (currently frozen)   | Design only        |
+| Action / lifecycle hooks | `config.on_action`                           | Design only        |
+
+### 2a. Resources, dashboards, tools (via load paths)
+
+These classes already self-register on load. The only thing a plugin must do
+is get its class files onto the host's Zeitwerk autoload/eager-load set with
+the `IronAdmin` namespace — exactly what `engine.rb` already does for the
+host's own `app/iron_admin` directory:
+
+```ruby
+Rails.autoloaders.main.push_dir(resource_path, namespace: IronAdmin)
+```
+
+**Proposed mechanism:** a plugin exposes a load path and IronAdmin pushes it
+during the `:set_autoload_paths`/`to_prepare` cycle:
+
+```ruby
+setup do |admin|
+  admin.load_path File.expand_path("../../app/iron_admin", __dir__)
+end
+```
+
+The directory follows the same layout as a host (`resources/`, `dashboards/`),
+so `MyPlugin::…` files defining `IronAdmin::Resources::FooResource` land in the
+registry through the existing `inherited` hook — **no new registration code for
+the resource itself.** This is why load-path contribution, not per-class
+registration, is the right abstraction here.
+
+**Open question for the maintainer:** eager-load ordering. Plugin dirs must be
+pushed *before* the engine's `to_prepare` eager-loads and calls
+`ResourceRegistry.finalize!`. This requires the host to `register_plugin`
+during engine initialization (an initializer that runs before
+`iron_admin.autoload`), which is a tighter ordering contract than the "call it
+anywhere" model the PoC uses for the config-level extension points. See §5.
+
+### 2b. Component overrides — **implemented**
+
+Delegates to `IronAdmin::Configuration::Components`. Any existing slot
+(`:table`, `:form`, `:navbar`, `:sidebar`, `:shell`, `:search`, `:filter_bar`)
+can be swapped:
+
+```ruby
+setup { |admin| admin.component :navbar, MyPlugin::NavbarComponent }
+```
+
+### 2c. Field types — **implemented**
+
+Delegates to `FieldTypeRegistry` with the same block DSL as
+`IronAdmin.register_field_type`:
+
+```ruby
+setup do |admin|
+  admin.field_type(:color) do
+    display { |record, field| record.public_send(field.name) }
+  end
+end
+```
+
+### 2d. Menu items — **implemented (new capability)**
+
+Before this proposal the sidebar could only render entries *derived from*
+registered resources and tools. Plugins frequently need to surface a page that
+is **not** a CRUD resource (a report, an external dashboard, a separately
+mounted engine). `MenuItem` + `MenuRegistry` add that as a first-class, small
+value object:
+
+```ruby
+setup do |admin|
+  admin.menu_item label: "Reports", path: "/admin/reports",
+                  icon: "chart-bar", group: "Analytics", priority: 20
+end
+```
+
+Items de-duplicate by `group + label + path`, so the idempotent re-activation
+on every `to_prepare` (development reloads) never produces duplicate entries.
+Wiring `MenuRegistry.grouped`/`.sorted` into `SidebarComponent` is a small,
+deliberately-deferred follow-up (see §7).
+
+### 2e. Adapters (design only)
+
+`Adapters::Registry::ADAPTERS` is currently a **frozen** hash, and
+`adapter_class` already accepts a class object directly — so a plugin *can*
+ship an adapter today by pointing a resource at its class. To make adapters
+first-class and referenceable by symbol (`self.adapter_class = :elasticsearch`)
+the frozen hash must become a mutable registry:
+
+```ruby
+setup { |admin| admin.adapter :elasticsearch, MyPlugin::ElasticsearchAdapter }
+```
+
+This is deferred because it requires converting `Adapters::Registry` from a
+constant lookup to a registration API and re-verifying the lazy-require
+behaviour that keeps ActiveRecord and Mongoid code mutually exclusive.
+
+### 2f. Lifecycle / action hooks (design only)
+
+`config.on_action` today supports a **single** block. A plugin needs to
+*subscribe* without clobbering the host's block or another plugin's. Proposed:
+promote `on_action` to a list of subscribers and expose
+`admin.on_action { |action, resource, record, user| … }`. Deferred because it
+changes the semantics of an existing public config method (a backward-compat
+concern the maintainer should rule on).
+
+## 3. Packaging model
+
+A plugin is an ordinary gem. Recommended layout:
+
+```
+iron_admin_reports/
+├── iron_admin_reports.gemspec        # depends on "iron_admin", ">= 0.6"
+├── lib/
+│   ├── iron_admin_reports.rb         # requires the plugin + engine
+│   └── iron_admin_reports/
+│       ├── plugin.rb                 # < IronAdmin::Plugin
+│       ├── engine.rb                 # optional: assets, routes, mount points
+│       └── navbar_component.rb
+└── app/
+    └── iron_admin/                   # follows host convention; Zeitwerk-mapped
+        ├── resources/…
+        └── dashboards/…
+```
+
+- The gemspec declares `spec.add_dependency "iron_admin", ">= 0.6", "< 2.0"` —
+  this is the coarse gate; the `requires_iron_admin` declaration (§5) is the
+  runtime-checked fine gate.
+- If the plugin ships its own routes/assets/mount points it includes a nested
+  `Rails::Engine`, orthogonal to the IronAdmin plugin object.
+- **The host stays in control:** adding the gem to the `Gemfile` loads the
+  code; nothing activates until the host calls `IronAdmin.register_plugin`. A
+  plugin gem must document that one line rather than auto-activating on
+  `require`, so hosts can audit and order activation.
+
+## 4. Registration API
+
+Two entry points:
+
+```ruby
+# Host initializer — config/initializers/iron_admin.rb
+require "iron_admin_reports"
+IronAdmin.register_plugin(IronAdminReports::Plugin)
+```
+
+```ruby
+# The plugin, in the gem
+module IronAdminReports
+  class Plugin < IronAdmin::Plugin
+    plugin_name       "iron_admin_reports"
+    plugin_version    "1.2.0"
+    requires_iron_admin ">= 0.6", "< 2.0"
+
+    setup do |admin|                       # `admin` is a Plugin::Registration
+      admin.menu_item label: "Reports", path: "/admin/reports",
+                      icon: "chart-bar", group: "Analytics", priority: 20
+      admin.component :navbar, IronAdminReports::NavbarComponent
+      admin.field_type(:currency) do
+        display { |record, field| record.public_send(field.name) }
+      end
+      # admin.load_path "…/app/iron_admin"   # (planned — §2a)
+      # admin.adapter :elasticsearch, …       # (planned — §2e)
+    end
+  end
+end
+```
+
+Class hierarchy:
+
+- **`IronAdmin::Plugin`** — base class. Declarative metadata
+  (`plugin_name`, `plugin_version`, `requires_iron_admin`) + a single `setup`
+  block. `activate!` checks compatibility then runs the block against a fresh
+  `Registration`.
+- **`IronAdmin::Plugin::Registration`** — the facade (§1). The *only* surface
+  plugin authors are promised stability on.
+- **`IronAdmin::PluginRegistry`** — stores activated plugin classes, keyed by
+  `plugin_name` (idempotent). `register` validates + activates; `activate_all!`
+  re-activates all (called from the engine on every `to_prepare`).
+- **`IronAdmin.register_plugin`** — the one host-facing entry point,
+  delegating to `PluginRegistry.register`.
+
+Why **explicit** registration rather than `inherited` auto-registration (which
+resources/tools use)? Two reasons: (1) determinism — the host controls
+activation order, which matters for load-path contribution (§2a); (2)
+auditability — a plugin is a bigger trust decision than a resource, so making
+the host name it explicitly is a feature, not friction.
+
+## 5. Versioning & compatibility
+
+- Each plugin declares `requires_iron_admin` using standard RubyGems
+  requirement syntax. At `activate!`, IronAdmin checks it against
+  `IronAdmin::VERSION` and raises `IronAdmin::IncompatiblePluginError` if
+  unsatisfied — a **loud, early** failure at boot rather than a mysterious
+  `NoMethodError` deep in a request.
+- IronAdmin should treat the `Registration` facade as **semver-governed public
+  API**: additive changes are minor bumps; removing/renaming a facade method is
+  a major bump. The facade's `requires_iron_admin` upper bound (`< 2.0`) is how
+  a plugin protects itself against a future breaking major.
+- **Activation ordering contract:** config-level extension points (component,
+  field type, menu item) can be registered any time after IronAdmin loads.
+  Load-path contribution (§2a) must happen during engine init. The maintainer
+  should decide whether to support both timings or require all plugins to
+  register in a dedicated `iron_admin.plugins` initializer.
+
+## 6. Security & isolation
+
+**There is no isolation, by design, and this must be documented prominently.**
+A plugin is arbitrary Ruby with full host privileges: it can read any model,
+issue any query, override the entire UI shell, and reach any secret the host
+process holds. The threat model is identical to any other gem in the `Gemfile`.
+
+Recommended posture:
+
+- **Trust before install.** Document that plugins are not sandboxed. Encourage
+  hosts to vet plugin source and pin exact versions.
+- **Explicit activation** (§4) is the mitigation that exists: nothing runs
+  until the host names it.
+- **Fail-safe activation.** Consider (future) wrapping each plugin's `activate!`
+  so one broken plugin logs and is skipped rather than taking down boot —
+  mirroring how `ResourceRegistry.finalize!` already isolates per-resource
+  failures. The PoC currently lets activation errors propagate (fail-loud),
+  which is the safer default until the maintainer chooses a policy.
+- **No privilege reduction is promised.** If per-plugin capability scoping is
+  ever wanted, it is a separate, much larger project and out of scope here.
+
+## 7. End-to-end example (fictional third-party plugin)
+
+`iron_admin_stripe` — surfaces Stripe data in the admin panel.
+
+```ruby
+# lib/iron_admin_stripe/plugin.rb
+module IronAdminStripe
+  class Plugin < IronAdmin::Plugin
+    plugin_name       "iron_admin_stripe"
+    plugin_version    "0.3.0"
+    requires_iron_admin ">= 0.6", "< 2.0"
+
+    setup do |admin|
+      # A read-only "Payments" report page the plugin's own engine mounts.
+      admin.menu_item label: "Payments", path: "/admin/stripe/payments",
+                      icon: "credit-card", group: "Billing", priority: 15
+
+      # A money renderer reused across the plugin's resources.
+      admin.field_type(:money) do
+        display { |record, field| "$%.2f" % (record.public_send(field.name).to_i / 100.0) }
+      end
+
+      # A branded navbar for the billing section.
+      admin.component :navbar, IronAdminStripe::NavbarComponent
+
+      # (planned) ship CRUD resources for cached Stripe objects:
+      # admin.load_path File.expand_path("../../app/iron_admin", __dir__)
+    end
+  end
+end
+```
+
+```ruby
+# Host app: config/initializers/iron_admin.rb
+require "iron_admin_stripe"
+
+IronAdmin.configure do |config|
+  config.title = "Acme Admin"
+end
+
+IronAdmin.register_plugin(IronAdminStripe::Plugin)
+```
+
+On boot: compatibility is checked against `0.6.0` → passes; the `:money` field
+type is registered; the navbar is overridden; and a "Payments" entry appears
+under a "Billing" group in the sidebar. If Acme later upgrades to IronAdmin
+`2.1`, the plugin refuses to activate with a clear
+`IncompatiblePluginError` until `iron_admin_stripe` ships a compatible release.
+
+## 8. What is implemented vs. deferred
+
+**Implemented (this PR):**
+
+- `IronAdmin::Plugin` base class (metadata DSL, `setup`, compatibility check,
+  `activate!`).
+- `IronAdmin::Plugin::Registration` facade with `menu_item`, `component`,
+  `field_type`.
+- `IronAdmin::PluginRegistry` (idempotent register/activate, `activate_all!`).
+- `IronAdmin.register_plugin` host entry point.
+- `IronAdmin::MenuItem` + `IronAdmin::MenuRegistry` (new sidebar extension
+  point).
+- `PluginError` / `IncompatiblePluginError`.
+- Engine re-activates plugins on `to_prepare`.
+- Full BetterSpecs coverage for the above.
+
+**Deferred (needs maintainer sign-off before building):**
+
+- `#load_path` — Zeitwerk dir contribution for resources/dashboards/tools, plus
+  the activation-ordering contract (§2a, §5).
+- `#adapter` — de-freeze `Adapters::Registry` into a mutable registry (§2e).
+- `#on_action` — multi-subscriber lifecycle hooks (§2f).
+- Rendering `MenuRegistry` entries in `SidebarComponent` (§2d).
+- Fail-safe (isolated) activation policy (§6).
+- Generators (`rails g iron_admin:plugin`) and published authoring guide.
+
+## 9. Decisions the maintainer must approve
+
+1. **Facade-as-contract**: commit to `Plugin::Registration` as the semver-
+   governed plugin API; internal registries stay private.
+2. **Explicit activation** over `inherited` auto-registration for plugins.
+3. **New `MenuItem`/`MenuRegistry`** as the sidebar extension point (vs.
+   forcing every nav entry through a resource/tool).
+4. **Activation timing / ordering** model for load-path contribution (§5).
+5. **Security posture**: ship "no isolation, trust-on-install" as documented
+   policy; decide fail-loud vs. fail-safe activation.
+6. **`on_action` compatibility**: whether to convert the single-block config
+   hook into a multi-subscriber list.
+```

--- a/lib/iron_admin.rb
+++ b/lib/iron_admin.rb
@@ -40,6 +40,10 @@ require "iron_admin/import/import_preview"
 require "iron_admin/import/import_result"
 require "iron_admin/import/importer"
 require "iron_admin/audit_log"
+require "iron_admin/menu_item"
+require "iron_admin/menu_registry"
+require "iron_admin/plugin"
+require "iron_admin/plugin_registry"
 require "iron_admin/engine"
 
 # IronAdmin is a convention-over-configuration admin panel engine for Ruby on Rails.
@@ -154,6 +158,25 @@ module IronAdmin
 
     def register_field_type(type_name, &)
       FieldTypeRegistry.register(type_name, &)
+    end
+
+    # Registers and activates an IronAdmin plugin.
+    #
+    # Call this from a host initializer (config/initializers/iron_admin.rb)
+    # after +require+-ing the plugin gem. The plugin's setup block runs
+    # immediately, wiring its extensions (menu items, component overrides,
+    # field types, ...) into the current install.
+    #
+    # @param plugin_class [Class] A subclass of {IronAdmin::Plugin}
+    # @return [Class] The registered plugin class
+    #
+    # @example
+    #   IronAdmin.register_plugin(IronAdminReports::Plugin)
+    #
+    # @see IronAdmin::Plugin
+    # @see IronAdmin::PluginRegistry
+    def register_plugin(plugin_class)
+      PluginRegistry.register(plugin_class)
     end
   end
 end

--- a/lib/iron_admin.rb
+++ b/lib/iron_admin.rb
@@ -167,6 +167,9 @@ module IronAdmin
     # immediately, wiring its extensions (menu items, component overrides,
     # field types, ...) into the current install.
     #
+    # @note EXPERIMENTAL — unstable until 1.0. The plugin API is not covered by
+    #   the zero-breaking-changes invariant and may change before GA.
+    #
     # @param plugin_class [Class] A subclass of {IronAdmin::Plugin}
     # @return [Class] The registered plugin class
     #

--- a/lib/iron_admin/engine.rb
+++ b/lib/iron_admin/engine.rb
@@ -76,6 +76,10 @@ module IronAdmin
         # steps (soft-delete features, etc.) with the correct adapter.
         IronAdmin::ResourceRegistry.finalize!
       end
+      # Re-activate registered plugins so their component overrides and menu
+      # items survive the per-reload configuration lifecycle. Activation is
+      # idempotent, so this is safe to run on every `to_prepare`.
+      IronAdmin::PluginRegistry.activate_all!
     end
   end
 end

--- a/lib/iron_admin/errors.rb
+++ b/lib/iron_admin/errors.rb
@@ -16,6 +16,14 @@ module IronAdmin
   # (network failure, invalid response, etc.).
   class AdapterError < Error; end
 
+  # Raised for plugin registration/activation problems
+  # (e.g. registering something that isn't a Plugin subclass).
+  class PluginError < Error; end
+
+  # Raised when a plugin declares an IronAdmin version requirement that the
+  # running version does not satisfy.
+  class IncompatiblePluginError < PluginError; end
+
   # Exception classes that mean the database is missing or unreachable
   # at boot time. Resolved lazily so the gem stays usable on
   # `--skip-active-record` hosts where `ActiveRecord` isn't loaded.

--- a/lib/iron_admin/menu_item.rb
+++ b/lib/iron_admin/menu_item.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module IronAdmin
+  # A custom navigation entry contributed to the admin sidebar.
+  #
+  # Unlike resource- and tool-derived menu entries (which are inferred from
+  # registered {Resource}/{Tool} classes), a MenuItem is an arbitrary link.
+  # Plugins use these to surface external pages, custom-mounted engines, or
+  # standalone report views in the sidebar without defining a full resource.
+  #
+  # @example
+  #   IronAdmin::MenuItem.new(
+  #     label: "Reports",
+  #     path: "/admin/reports",
+  #     icon: "chart-bar",
+  #     group: "Analytics",
+  #     priority: 50
+  #   )
+  #
+  # @see IronAdmin::MenuRegistry
+  class MenuItem
+    # @return [String] Human-readable label rendered in the sidebar
+    attr_reader :label
+
+    # @return [String] URL or path the entry links to
+    attr_reader :path
+
+    # @return [String, nil] Optional heroicon name shown beside the label
+    attr_reader :icon
+
+    # @return [String] Sidebar group heading (defaults to "Plugins")
+    attr_reader :group
+
+    # @return [Integer] Sort weight within the group (lower shows first)
+    attr_reader :priority
+
+    # @param label [String] Human-readable label
+    # @param path [String] URL or path to link to
+    # @param icon [String, nil] Optional heroicon name
+    # @param group [String] Sidebar group heading
+    # @param priority [Integer] Sort weight within the group
+    # @raise [ArgumentError] If label or path is blank
+    def initialize(label:, path:, icon: nil, group: "Plugins", priority: 999)
+      raise ArgumentError, "MenuItem label can't be blank" if label.nil? || label.to_s.strip.empty?
+      raise ArgumentError, "MenuItem path can't be blank" if path.nil? || path.to_s.strip.empty?
+
+      @label = label.to_s
+      @path = path.to_s
+      @icon = icon
+      @group = (group || "Plugins").to_s
+      @priority = priority || 999
+    end
+
+    # A stable identity key used to de-duplicate menu items across repeated
+    # activation passes (e.g. Rails `to_prepare` re-runs in development).
+    #
+    # @return [String]
+    def key
+      "#{group}::#{label}::#{path}"
+    end
+  end
+end

--- a/lib/iron_admin/menu_item.rb
+++ b/lib/iron_admin/menu_item.rb
@@ -38,7 +38,8 @@ module IronAdmin
     # @param path [String] URL or path to link to
     # @param icon [String, nil] Optional heroicon name
     # @param group [String] Sidebar group heading
-    # @param priority [Integer] Sort weight within the group
+    # @param priority [Integer] Sort weight within the group. Coerced to an
+    #   Integer; non-numeric values fall back to 999 so sorting never raises.
     # @raise [ArgumentError] If label or path is blank
     def initialize(label:, path:, icon: nil, group: "Plugins", priority: 999)
       raise ArgumentError, "MenuItem label can't be blank" if label.nil? || label.to_s.strip.empty?
@@ -47,8 +48,8 @@ module IronAdmin
       @label = label.to_s
       @path = path.to_s
       @icon = icon
-      @group = (group || "Plugins").to_s
-      @priority = priority || 999
+      @group = group.nil? || group.to_s.strip.empty? ? "Plugins" : group.to_s
+      @priority = Integer(priority, exception: false) || 999
     end
 
     # A stable identity key used to de-duplicate menu items across repeated

--- a/lib/iron_admin/menu_registry.rb
+++ b/lib/iron_admin/menu_registry.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module IronAdmin
+  # Registry of custom sidebar {MenuItem}s contributed outside the
+  # resource/tool convention — primarily by plugins.
+  #
+  # Items are de-duplicated by their {MenuItem#key}, so re-activating a
+  # plugin (as happens on every Rails `to_prepare` in development) does not
+  # produce duplicate sidebar entries.
+  #
+  # @see IronAdmin::MenuItem
+  # @see IronAdmin::PluginRegistry
+  class MenuRegistry
+    class << self
+      # Adds a menu item to the registry (idempotent by {MenuItem#key}).
+      #
+      # @param menu_item [IronAdmin::MenuItem] The item to add
+      # @return [IronAdmin::MenuItem] The registered item
+      def register(menu_item)
+        items[menu_item.key] = menu_item
+      end
+
+      # @return [Array<IronAdmin::MenuItem>] All registered items
+      def all
+        items.values
+      end
+
+      # Returns items grouped by their sidebar group heading.
+      #
+      # @return [Hash{String => Array<IronAdmin::MenuItem>}]
+      def grouped
+        all.group_by(&:group)
+      end
+
+      # Returns items sorted by priority (ascending).
+      #
+      # @return [Array<IronAdmin::MenuItem>]
+      def sorted
+        all.sort_by(&:priority)
+      end
+
+      # Clears all registered menu items.
+      #
+      # @api private
+      # @return [void]
+      def reset!
+        @items = {}
+      end
+
+      private
+
+      def items
+        @items ||= {}
+      end
+    end
+  end
+end

--- a/lib/iron_admin/plugin.rb
+++ b/lib/iron_admin/plugin.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "iron_admin/plugin/registration"
+
+module IronAdmin
+  # Base class for IronAdmin community/extension plugins.
+  #
+  # A plugin is a small declarative wrapper — usually shipped inside an
+  # external Rails gem — that hooks its extensions into a host application's
+  # IronAdmin install. Subclass this, declare metadata, and describe what to
+  # register in a {.setup} block. The block runs against a
+  # {Plugin::Registration} facade when the plugin is activated, so plugin code
+  # never depends on IronAdmin's internal registry classes directly.
+  #
+  # @example A minimal plugin
+  #   module IronAdminReports
+  #     class Plugin < IronAdmin::Plugin
+  #       plugin_name "iron_admin_reports"
+  #       plugin_version "1.2.0"
+  #       requires_iron_admin ">= 0.6", "< 2.0"
+  #
+  #       setup do |admin|
+  #         admin.menu_item label: "Reports", path: "/admin/reports",
+  #                         icon: "chart-bar", group: "Analytics", priority: 20
+  #         admin.component :navbar, IronAdminReports::NavbarComponent
+  #       end
+  #     end
+  #   end
+  #
+  #   # In the host app's config/initializers/iron_admin.rb:
+  #   IronAdmin.register_plugin(IronAdminReports::Plugin)
+  #
+  # @see IronAdmin.register_plugin
+  # @see IronAdmin::PluginRegistry
+  # @see IronAdmin::Plugin::Registration
+  class Plugin
+    class << self
+      # Declares (or reads) the plugin's unique identifier.
+      #
+      # @param value [String, nil] The plugin name when setting
+      # @return [String] The plugin name
+      def plugin_name(value = nil)
+        @plugin_name = value.to_s if value
+        @plugin_name || name.to_s
+      end
+
+      # Declares (or reads) the plugin's own version string.
+      #
+      # @param value [String, nil] The version when setting
+      # @return [String, nil] The plugin version
+      def plugin_version(value = nil)
+        @plugin_version = value.to_s if value
+        @plugin_version
+      end
+
+      # Declares the IronAdmin version constraint this plugin supports.
+      #
+      # Accepts the same syntax as a gemspec dependency (one or more
+      # RubyGems requirement strings). Checked at activation time against
+      # {IronAdmin::VERSION}.
+      #
+      # @param constraints [Array<String>] RubyGems requirement strings
+      # @return [Gem::Requirement, nil] The parsed requirement
+      def requires_iron_admin(*constraints)
+        @iron_admin_requirement = Gem::Requirement.new(*constraints) unless constraints.empty?
+        @iron_admin_requirement
+      end
+
+      # Registers the setup block that describes what the plugin contributes.
+      #
+      # The block receives a {Plugin::Registration} facade when the plugin is
+      # activated. Only one setup block is supported per plugin.
+      #
+      # @yield [registration] The registration facade
+      # @yieldparam registration [IronAdmin::Plugin::Registration]
+      # @return [void]
+      def setup(&block)
+        @setup_block = block
+      end
+
+      # Verifies this plugin is compatible with the running IronAdmin version.
+      #
+      # @param iron_admin_version [String] Version to check against
+      # @return [Boolean]
+      def compatible_with?(iron_admin_version = IronAdmin::VERSION)
+        requirement = requires_iron_admin
+        return true if requirement.nil?
+
+        requirement.satisfied_by?(Gem::Version.new(iron_admin_version))
+      end
+
+      # Runs the plugin's setup block against a fresh registration facade.
+      #
+      # @raise [IronAdmin::IncompatiblePluginError] When the running
+      #   IronAdmin version does not satisfy {.requires_iron_admin}
+      # @return [void]
+      def activate!
+        unless compatible_with?
+          raise IncompatiblePluginError,
+                "Plugin #{plugin_name} requires IronAdmin #{requires_iron_admin} " \
+                "but #{IronAdmin::VERSION} is loaded"
+        end
+
+        @setup_block&.call(Registration.new(self))
+      end
+    end
+  end
+end

--- a/lib/iron_admin/plugin.rb
+++ b/lib/iron_admin/plugin.rb
@@ -5,6 +5,12 @@ require "iron_admin/plugin/registration"
 module IronAdmin
   # Base class for IronAdmin community/extension plugins.
   #
+  # @note EXPERIMENTAL — unstable until 1.0. This class and the whole plugin
+  #   API (`IronAdmin.register_plugin`, {Plugin::Registration}, {MenuItem},
+  #   {MenuRegistry}) are not covered by the project's zero-breaking-changes
+  #   invariant and may change or be removed before general availability (GA
+  #   targeted for 1.0).
+  #
   # A plugin is a small declarative wrapper — usually shipped inside an
   # external Rails gem — that hooks its extensions into a host application's
   # IronAdmin install. Subclass this, declare metadata, and describe what to

--- a/lib/iron_admin/plugin/registration.rb
+++ b/lib/iron_admin/plugin/registration.rb
@@ -65,10 +65,17 @@ module IronAdmin
       # Delegates to {IronAdmin::FieldTypeRegistry}. Accepts the same block
       # DSL as {IronAdmin.register_field_type}.
       #
+      # Idempotent under re-activation: unlike component overrides (which are
+      # re-applied on every +to_prepare+), field types live in a process-wide
+      # registry that is not reset on reload, so re-registering an existing
+      # type name is a no-op instead of raising.
+      #
       # @param type_name [Symbol] The field type identifier
       # @yield Field type configuration block
       # @return [void]
       def field_type(type_name, &)
+        return if FieldTypeRegistry.registered?(type_name)
+
         FieldTypeRegistry.register(type_name, &)
       end
     end

--- a/lib/iron_admin/plugin/registration.rb
+++ b/lib/iron_admin/plugin/registration.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module IronAdmin
+  class Plugin
+    # Facade passed to a {Plugin.setup} block during activation.
+    #
+    # Registration exposes a small, stable surface for plugins to hook into
+    # IronAdmin's extension points. It deliberately hides the concrete
+    # registry/configuration classes so that internal refactors don't break
+    # third-party plugins — this facade is the plugin API contract.
+    #
+    # == Implemented extension points (proof of concept)
+    #
+    # - {#menu_item}  — contribute a custom sidebar link
+    # - {#component}  — override a global UI component
+    # - {#field_type} — register a custom field type renderer
+    #
+    # == Planned extension points (design only — see docs/plugin-system-design.md)
+    #
+    # - +#adapter+     — register a data-source adapter
+    # - +#load_path+   — contribute a Zeitwerk dir of resources/dashboards/tools
+    # - +#on_action+   — subscribe to CRUD lifecycle events
+    #
+    # @see IronAdmin::Plugin
+    class Registration
+      # @param plugin [Class] The plugin class being activated
+      def initialize(plugin)
+        @plugin = plugin
+      end
+
+      # Contributes a custom link to the admin sidebar.
+      #
+      # @param label [String] Human-readable label
+      # @param path [String] URL or path to link to
+      # @param icon [String, nil] Optional heroicon name
+      # @param group [String] Sidebar group heading (default "Plugins")
+      # @param priority [Integer] Sort weight within the group
+      # @return [IronAdmin::MenuItem] The registered item
+      def menu_item(label:, path:, icon: nil, group: "Plugins", priority: 999)
+        item = MenuItem.new(label: label, path: path, icon: icon, group: group, priority: priority)
+        MenuRegistry.register(item)
+      end
+
+      # Overrides one of IronAdmin's global UI components.
+      #
+      # Delegates to {IronAdmin::Configuration::Components}. Valid names match
+      # its accessors (e.g. +:table+, +:form+, +:navbar+, +:sidebar+,
+      # +:shell+, +:search+, +:filter_bar+).
+      #
+      # @param name [Symbol] The component slot to override
+      # @param component_class [Class] The replacement ViewComponent class
+      # @raise [ArgumentError] If +name+ is not a known component slot
+      # @return [Class] The registered component class
+      def component(name, component_class)
+        components = IronAdmin.configuration.components
+        writer = "#{name}="
+        raise ArgumentError, "Unknown component slot: #{name.inspect}" unless components.respond_to?(writer)
+
+        components.public_send(writer, component_class)
+        component_class
+      end
+
+      # Registers a custom field type renderer.
+      #
+      # Delegates to {IronAdmin::FieldTypeRegistry}. Accepts the same block
+      # DSL as {IronAdmin.register_field_type}.
+      #
+      # @param type_name [Symbol] The field type identifier
+      # @yield Field type configuration block
+      # @return [void]
+      def field_type(type_name, &)
+        FieldTypeRegistry.register(type_name, &)
+      end
+    end
+  end
+end

--- a/lib/iron_admin/plugin_registry.rb
+++ b/lib/iron_admin/plugin_registry.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module IronAdmin
+  # Registry of {Plugin} classes activated in the host application.
+  #
+  # Plugins are registered explicitly (typically from a host initializer via
+  # {IronAdmin.register_plugin}), unlike resources/tools which self-register on
+  # inheritance. Explicit registration keeps activation ordering deterministic
+  # and gives the host a single, auditable list of everything that extends its
+  # admin panel.
+  #
+  # @see IronAdmin::Plugin
+  # @see IronAdmin.register_plugin
+  class PluginRegistry
+    class << self
+      # Registers and immediately activates a plugin.
+      #
+      # Registration is idempotent by {Plugin.plugin_name}: re-registering the
+      # same plugin re-activates it (used on Rails +to_prepare+ reloads) rather
+      # than adding a duplicate.
+      #
+      # @param plugin_class [Class] A subclass of {IronAdmin::Plugin}
+      # @raise [IronAdmin::PluginError] If +plugin_class+ is not a Plugin subclass
+      # @raise [IronAdmin::IncompatiblePluginError] If the plugin is incompatible
+      # @return [Class] The registered plugin class
+      def register(plugin_class)
+        unless plugin_class.is_a?(Class) && plugin_class < IronAdmin::Plugin
+          raise PluginError, "#{plugin_class.inspect} is not an IronAdmin::Plugin subclass"
+        end
+
+        plugins[plugin_class.plugin_name] = plugin_class
+        plugin_class.activate!
+        plugin_class
+      end
+
+      # Re-activates every registered plugin.
+      #
+      # Called by the engine on boot/reload so component overrides and menu
+      # items survive the per-request configuration lifecycle. Activation is
+      # idempotent, so repeated calls are safe.
+      #
+      # @return [void]
+      def activate_all!
+        all.each(&:activate!)
+      end
+
+      # @return [Array<Class>] All registered plugin classes
+      def all
+        plugins.values
+      end
+
+      # Finds a registered plugin by name.
+      #
+      # @param plugin_name [String] The plugin identifier
+      # @return [Class, nil]
+      def find(plugin_name)
+        plugins[plugin_name.to_s]
+      end
+
+      # Clears all registered plugins.
+      #
+      # @api private
+      # @return [void]
+      def reset!
+        @plugins = {}
+      end
+
+      private
+
+      def plugins
+        @plugins ||= {}
+      end
+    end
+  end
+end

--- a/lib/iron_admin/plugin_registry.rb
+++ b/lib/iron_admin/plugin_registry.rb
@@ -20,7 +20,8 @@ module IronAdmin
       # than adding a duplicate.
       #
       # @param plugin_class [Class] A subclass of {IronAdmin::Plugin}
-      # @raise [IronAdmin::PluginError] If +plugin_class+ is not a Plugin subclass
+      # @raise [IronAdmin::PluginError] If +plugin_class+ is not a Plugin
+      #   subclass or declares a blank +plugin_name+
       # @raise [IronAdmin::IncompatiblePluginError] If the plugin is incompatible
       # @return [Class] The registered plugin class
       def register(plugin_class)
@@ -28,8 +29,14 @@ module IronAdmin
           raise PluginError, "#{plugin_class.inspect} is not an IronAdmin::Plugin subclass"
         end
 
-        plugins[plugin_class.plugin_name] = plugin_class
+        name = plugin_class.plugin_name
+        raise PluginError, "#{plugin_class.inspect} must declare a non-blank plugin_name" if name.nil? || name.to_s.strip.empty?
+
+        # Activate before storing so a plugin that fails activation (incompatible
+        # version, or an exception in its setup block) is not left registered to
+        # re-fail on every subsequent activate_all! pass.
         plugin_class.activate!
+        plugins[name] = plugin_class
         plugin_class
       end
 

--- a/spec/lib/iron_admin/menu_item_spec.rb
+++ b/spec/lib/iron_admin/menu_item_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IronAdmin::MenuItem do
+  subject(:menu_item) { described_class.new(label: "Reports", path: "/admin/reports") }
+
+  describe "#initialize" do
+    context "with only required attributes" do
+      it "defaults the group to 'Plugins'" do
+        expect(menu_item.group).to eq("Plugins")
+      end
+
+      it "defaults the priority to 999" do
+        expect(menu_item.priority).to eq(999)
+      end
+
+      it "defaults the icon to nil" do
+        expect(menu_item.icon).to be_nil
+      end
+    end
+
+    context "with a blank label" do
+      it "raises an ArgumentError" do
+        expect { described_class.new(label: "  ", path: "/x") }
+          .to raise_error(ArgumentError, /label can't be blank/)
+      end
+    end
+
+    context "with a blank path" do
+      it "raises an ArgumentError" do
+        expect { described_class.new(label: "Reports", path: "") }
+          .to raise_error(ArgumentError, /path can't be blank/)
+      end
+    end
+  end
+
+  describe "#key" do
+    it "combines group, label, and path" do
+      item = described_class.new(label: "Reports", path: "/admin/reports", group: "Analytics")
+      expect(item.key).to eq("Analytics::Reports::/admin/reports")
+    end
+  end
+end

--- a/spec/lib/iron_admin/menu_item_spec.rb
+++ b/spec/lib/iron_admin/menu_item_spec.rb
@@ -33,6 +33,25 @@ RSpec.describe IronAdmin::MenuItem do
           .to raise_error(ArgumentError, /path can't be blank/)
       end
     end
+
+    context "with a non-integer priority" do
+      it "coerces a numeric string to an Integer" do
+        item = described_class.new(label: "Reports", path: "/x", priority: "50")
+        expect(item.priority).to eq(50)
+      end
+
+      it "falls back to 999 for a non-numeric value" do
+        item = described_class.new(label: "Reports", path: "/x", priority: "high")
+        expect(item.priority).to eq(999)
+      end
+    end
+
+    context "with a blank group" do
+      it "normalizes it to 'Plugins'" do
+        item = described_class.new(label: "Reports", path: "/x", group: "  ")
+        expect(item.group).to eq("Plugins")
+      end
+    end
   end
 
   describe "#key" do

--- a/spec/lib/iron_admin/menu_registry_spec.rb
+++ b/spec/lib/iron_admin/menu_registry_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IronAdmin::MenuRegistry do
+  def build_item(label: "Reports", path: "/admin/reports", **opts)
+    IronAdmin::MenuItem.new(label: label, path: path, **opts)
+  end
+
+  describe ".register" do
+    it "adds the item to the registry" do
+      described_class.register(build_item)
+      expect(described_class.all.map(&:label)).to eq(["Reports"])
+    end
+
+    context "when registering the same item twice" do
+      it "does not create a duplicate" do
+        described_class.register(build_item)
+        described_class.register(build_item)
+        expect(described_class.all.size).to eq(1)
+      end
+    end
+  end
+
+  describe ".grouped" do
+    it "groups items by their group heading" do
+      described_class.register(build_item(label: "A", path: "/a", group: "Analytics"))
+      described_class.register(build_item(label: "B", path: "/b", group: "Ops"))
+
+      expect(described_class.grouped.keys).to contain_exactly("Analytics", "Ops")
+    end
+  end
+
+  describe ".sorted" do
+    it "orders items by ascending priority" do
+      described_class.register(build_item(label: "Second", path: "/2", priority: 20))
+      described_class.register(build_item(label: "First", path: "/1", priority: 10))
+
+      expect(described_class.sorted.map(&:label)).to eq(%w[First Second])
+    end
+  end
+
+  describe ".reset!" do
+    it "clears all items" do
+      described_class.register(build_item)
+      described_class.reset!
+      expect(described_class.all).to be_empty
+    end
+  end
+end

--- a/spec/lib/iron_admin/plugin_registry_spec.rb
+++ b/spec/lib/iron_admin/plugin_registry_spec.rb
@@ -60,6 +60,18 @@ RSpec.describe IronAdmin::PluginRegistry do
       described_class.activate_all!
       expect(call_count).to eq(2)
     end
+
+    context "when a plugin registers a field type (re-activated on to_prepare reloads)" do
+      it "does not raise on the second activation" do
+        plugin = build_plugin(name: "swatch") do
+          setup { |admin| admin.field_type(:plugin_swatch) { display { |v| v } } }
+        end
+        described_class.register(plugin) # first activation registers the type
+
+        expect { described_class.activate_all! }.not_to raise_error
+        expect(IronAdmin::FieldTypeRegistry.registered?(:plugin_swatch)).to be true
+      end
+    end
   end
 
   describe ".reset!" do

--- a/spec/lib/iron_admin/plugin_registry_spec.rb
+++ b/spec/lib/iron_admin/plugin_registry_spec.rb
@@ -42,11 +42,29 @@ RSpec.describe IronAdmin::PluginRegistry do
       end
     end
 
+    context "with a blank plugin_name" do
+      it "raises a PluginError" do
+        plugin = Class.new(IronAdmin::Plugin) { plugin_name "  " }
+        expect { described_class.register(plugin) }
+          .to raise_error(IronAdmin::PluginError, /non-blank plugin_name/)
+      end
+    end
+
     context "with an incompatible plugin" do
       it "raises IncompatiblePluginError" do
         plugin = build_plugin { requires_iron_admin ">= 99.0" }
         expect { described_class.register(plugin) }
           .to raise_error(IronAdmin::IncompatiblePluginError)
+      end
+
+      it "does not leave the plugin registered when activation fails" do
+        plugin = build_plugin(name: "broken") { requires_iron_admin ">= 99.0" }
+        begin
+          described_class.register(plugin)
+        rescue IronAdmin::IncompatiblePluginError
+          # expected — we only care that the failed plugin was not stored
+        end
+        expect(described_class.find("broken")).to be_nil
       end
     end
   end

--- a/spec/lib/iron_admin/plugin_registry_spec.rb
+++ b/spec/lib/iron_admin/plugin_registry_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IronAdmin::PluginRegistry do
+  def build_plugin(name: "test_plugin", &body)
+    Class.new(IronAdmin::Plugin) do
+      plugin_name name
+      instance_eval(&body) if body
+    end
+  end
+
+  describe ".register" do
+    context "with a valid plugin" do
+      it "stores the plugin" do
+        plugin = build_plugin(name: "reports")
+        described_class.register(plugin)
+        expect(described_class.find("reports")).to eq(plugin)
+      end
+
+      it "activates the plugin immediately" do
+        activated = false
+        plugin = build_plugin { setup { |_admin| activated = true } }
+
+        described_class.register(plugin)
+        expect(activated).to be true
+      end
+    end
+
+    context "when registering the same plugin name twice" do
+      it "does not create a duplicate entry" do
+        described_class.register(build_plugin(name: "dup"))
+        described_class.register(build_plugin(name: "dup"))
+        expect(described_class.all.size).to eq(1)
+      end
+    end
+
+    context "with an object that is not a Plugin subclass" do
+      it "raises a PluginError" do
+        expect { described_class.register(Class.new) }
+          .to raise_error(IronAdmin::PluginError, /not an IronAdmin::Plugin subclass/)
+      end
+    end
+
+    context "with an incompatible plugin" do
+      it "raises IncompatiblePluginError" do
+        plugin = build_plugin { requires_iron_admin ">= 99.0" }
+        expect { described_class.register(plugin) }
+          .to raise_error(IronAdmin::IncompatiblePluginError)
+      end
+    end
+  end
+
+  describe ".activate_all!" do
+    it "re-runs activation for every registered plugin" do
+      call_count = 0
+      plugin = build_plugin { setup { |_admin| call_count += 1 } }
+      described_class.register(plugin) # first activation
+
+      described_class.activate_all!
+      expect(call_count).to eq(2)
+    end
+  end
+
+  describe ".reset!" do
+    it "clears all registered plugins" do
+      described_class.register(build_plugin)
+      described_class.reset!
+      expect(described_class.all).to be_empty
+    end
+  end
+end

--- a/spec/lib/iron_admin/plugin_spec.rb
+++ b/spec/lib/iron_admin/plugin_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IronAdmin::Plugin do
+  # Builds an anonymous plugin subclass with an explicit name so it does not
+  # depend on constant assignment.
+  def build_plugin(name: "test_plugin", &body)
+    Class.new(described_class) do
+      plugin_name name
+      instance_eval(&body) if body
+    end
+  end
+
+  describe ".plugin_name" do
+    it "returns the declared name" do
+      plugin = build_plugin(name: "reports")
+      expect(plugin.plugin_name).to eq("reports")
+    end
+  end
+
+  describe ".plugin_version" do
+    it "returns the declared version" do
+      plugin = build_plugin { plugin_version "1.2.0" }
+      expect(plugin.plugin_version).to eq("1.2.0")
+    end
+  end
+
+  describe ".compatible_with?" do
+    context "when no requirement is declared" do
+      it "is always compatible" do
+        plugin = build_plugin
+        expect(plugin).to be_compatible_with("0.6.0")
+      end
+    end
+
+    context "when the running version satisfies the requirement" do
+      it "returns true" do
+        plugin = build_plugin { requires_iron_admin ">= 0.6", "< 2.0" }
+        expect(plugin.compatible_with?("0.6.0")).to be true
+      end
+    end
+
+    context "when the running version does not satisfy the requirement" do
+      it "returns false" do
+        plugin = build_plugin { requires_iron_admin ">= 2.0" }
+        expect(plugin.compatible_with?("0.6.0")).to be false
+      end
+    end
+  end
+
+  describe ".activate!" do
+    context "when the plugin is compatible" do
+      it "runs the setup block with a Registration facade" do
+        received = nil
+        plugin = build_plugin do
+          setup { |admin| received = admin }
+        end
+
+        plugin.activate!
+        expect(received).to be_a(IronAdmin::Plugin::Registration)
+      end
+    end
+
+    context "when the plugin is incompatible" do
+      it "raises IncompatiblePluginError" do
+        plugin = build_plugin { requires_iron_admin ">= 99.0" }
+        expect { plugin.activate! }
+          .to raise_error(IronAdmin::IncompatiblePluginError, /requires IronAdmin/)
+      end
+    end
+  end
+end
+
+RSpec.describe IronAdmin::Plugin::Registration do
+  subject(:registration) { described_class.new(plugin) }
+
+  let(:plugin) { Class.new(IronAdmin::Plugin) { plugin_name "test" } }
+
+  describe "#menu_item" do
+    it "registers a MenuItem in the MenuRegistry" do
+      registration.menu_item(label: "Reports", path: "/admin/reports")
+      expect(IronAdmin::MenuRegistry.all.map(&:label)).to eq(["Reports"])
+    end
+  end
+
+  describe "#component" do
+    let(:custom_component) { Class.new }
+
+    context "with a known component slot" do
+      it "overrides the component on the global configuration" do
+        registration.component(:navbar, custom_component)
+        expect(IronAdmin.configuration.components.navbar).to eq(custom_component)
+      end
+    end
+
+    context "with an unknown component slot" do
+      it "raises an ArgumentError" do
+        expect { registration.component(:nope, custom_component) }
+          .to raise_error(ArgumentError, /Unknown component slot/)
+      end
+    end
+  end
+
+  describe "#field_type" do
+    it "registers a field type in the FieldTypeRegistry" do
+      registration.field_type(:color) do
+        display { |record, field| record.public_send(field.name) }
+      end
+
+      expect(IronAdmin::FieldTypeRegistry.registered?(:color)).to be true
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,6 +47,8 @@ RSpec.configure do |config|
     IronAdmin::AuditLog.clear!
     IronAdmin::FieldTypeRegistry.reset!
     IronAdmin::ToolRegistry.reset!
+    IronAdmin::MenuRegistry.reset!
+    IronAdmin::PluginRegistry.reset!
   end
 
   config.before(:each, type: :request) do


### PR DESCRIPTION
Closes #109.

**Design-first** deliverable for the community extension system: a full design proposal plus an **experimental** proof-of-concept that validates the core.

## What's here
- **Design doc** `docs/plugin-system-design.md` — philosophy, extension points, packaging, registration API, versioning/security, end-to-end example, deferred work + decisions needing sign-off.
- **PoC (experimental):** `IronAdmin::Plugin` base class, `PluginRegistry` + `IronAdmin.register_plugin`, `Plugin::Registration` facade with 3 working extension points (`menu_item`, `component`, `field_type`), and `MenuItem`/`MenuRegistry` (new sidebar point).

## ⚠️ Stability
The plugin API (`register_plugin`, `Plugin`, `Registration`, `MenuItem`, `MenuRegistry`) is marked **EXPERIMENTAL / unstable until 1.0** in the changelog, design doc, and YARD docs — it is **not** bound by the zero-breaking-changes invariant until GA.

## Deferred to GA (documented)
`#load_path` (Zeitwerk dirs), `#adapter`, `#on_action` multi-subscriber, `MenuRegistry` → `SidebarComponent` rendering, per-extension-point collision/override policy, fail-safe activation, generators.

## Notes
- `field_type` registration is idempotent under `to_prepare` re-activation (field types live in a process-wide registry); covered by a new spec.

## Verification
- `bundle exec rspec` → **1999 examples, 0 failures**
- `bundle exec rubocop` → **0 offenses**

🤖 Generated with [Claude Code](https://claude.com/claude-code)