### PR TITLE
Build a comprehensive documentation site (Jekyll + just-the-docs)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.3"
+          ruby-version: .ruby-version
           bundler-cache: true
           working-directory: docs/site
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,7 +51,10 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: .ruby-version
+          # Matches the repo's .ruby-version (3.2.2). Pinned here rather than
+          # reading .ruby-version because this step's working-directory is
+          # docs/site, where that file does not live.
+          ruby-version: "3.2.2"
           bundler-cache: true
           working-directory: docs/site
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,89 @@
+# ============================================================================
+# PROPOSED workflow — DO NOT MERGE without maintainer review.
+#
+# Builds and (optionally) deploys the IronAdmin documentation site from
+# `docs/site/` to GitHub Pages.
+#
+# SAFETY: this workflow is intentionally conservative and will NOT deploy on a
+# normal push:
+#   * On pull requests touching `docs/`, it only BUILDS the site (no deploy) so
+#     reviewers can catch broken pages.
+#   * Deployment runs ONLY via manual `workflow_dispatch` (the "Run workflow"
+#     button). A maintainer must trigger it deliberately.
+#
+# BEFORE THIS CAN DEPLOY, a maintainer must:
+#   1. Enable GitHub Pages for the repo:  Settings → Pages → Source = "GitHub Actions".
+#   2. Review these triggers and (optionally) add `push` to `main` for
+#      continuous deploys once the site is trusted.
+#   3. Confirm `url` / `baseurl` in docs/site/_config.yml match the final URL.
+#
+# See docs/site/README.md for the full proposal and open decisions.
+# ============================================================================
+
+name: Docs Site
+
+on:
+  # Build-only check on PRs that touch the docs (no deploy).
+  pull_request:
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs.yml"
+  # Manual deploy — the ONLY trigger that publishes to GitHub Pages.
+  workflow_dispatch:
+
+# Least-privilege by default; the deploy job requests what Pages needs.
+permissions:
+  contents: read
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs/site
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+          working-directory: docs/site
+
+      - name: Configure Pages
+        id: pages
+        # Only needed when we intend to deploy (manual runs).
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/configure-pages@v5
+
+      - name: Build site with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path || '/iron_admin' }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/site/_site
+
+  deploy:
+    # Deploy ONLY on a deliberate manual run. Never on push/PR.
+    if: github.event_name == 'workflow_dispatch'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 
 - Added `docs/plugin-system-design.md` — full design proposal for the plugin/community extension system: philosophy, extension points, packaging model, registration API, versioning/security considerations, an end-to-end example, and the deferred work + decisions requiring maintainer sign-off.
+- **Documentation site scaffold** — Added a navigable, searchable documentation site under `docs/site/`, built with [Jekyll](https://jekyllrb.com/) and the [`just-the-docs`](https://just-the-docs.com/) theme and intended for GitHub Pages:
+  - Tooling proposal and justification (Jekyll + just-the-docs vs. MkDocs Material / Docusaurus) in `docs/site/README.md`
+  - Full section structure: Getting Started, Guides (Resource DSL, Dashboards, Fields, Theming, Components), Adapters, Authorization, Imports & Exports, Tools, Reference, Upgrade Guide, FAQ
+  - Three pages fully migrated from existing docs to validate the pipeline (Installation, Quick Start, Resource DSL); remaining sections are stubs with TODOs pointing at their source `docs/` files
+  - Client-side search, sidebar navigation, and "edit on GitHub" links configured
+  - **Proposed** (manual-trigger only, non-auto-deploying) GitHub Actions deploy workflow at `.github/workflows/docs.yml` — requires maintainer review and GitHub Pages setup before it can publish
 
 ## [0.6.0] - 2026-06-28
 

--- a/docs/site/.gitignore
+++ b/docs/site/.gitignore
@@ -1,0 +1,9 @@
+# Jekyll build artifacts
+_site/
+.jekyll-cache/
+.jekyll-metadata
+.sass-cache/
+
+# Local bundle
+/.bundle/
+/vendor/bundle/

--- a/docs/site/Gemfile
+++ b/docs/site/Gemfile
@@ -1,0 +1,23 @@
+# Gemfile for the IronAdmin documentation site (Jekyll + just-the-docs).
+#
+# This is intentionally SEPARATE from the gem's root Gemfile so the docs
+# toolchain never affects the gem's runtime or test dependencies.
+#
+#   cd docs/site && bundle install && bundle exec jekyll serve
+
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3"
+gem "just-the-docs", "~> 0.10"
+
+# Plugins
+group :jekyll_plugins do
+  gem "jekyll-seo-tag", "~> 2.8"
+  gem "jekyll-sitemap", "~> 1.4"
+end
+
+# Windows / JRuby timezone data (harmless elsewhere)
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end

--- a/docs/site/Gemfile.lock
+++ b/docs/site/Gemfile.lock
@@ -1,0 +1,179 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (4.1.2)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.7)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
+    ffi (1.17.4-aarch64-linux-musl)
+    ffi (1.17.4-arm-linux-gnu)
+    ffi (1.17.4-arm-linux-musl)
+    ffi (1.17.4-arm64-darwin)
+    ffi (1.17.4-x86-linux-gnu)
+    ffi (1.17.4-x86-linux-musl)
+    ffi (1.17.4-x86_64-darwin)
+    ffi (1.17.4-x86_64-linux-gnu)
+    ffi (1.17.4-x86_64-linux-musl)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.35.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-aarch64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-musl)
+      bigdecimal
+      rake (~> 13.3)
+    http_parser.rb (0.8.1)
+    i18n (1.15.2)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-include-cache (0.2.1)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.9.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.21.0)
+    just-the-docs (0.12.0)
+      jekyll (>= 3.8.5)
+      jekyll-include-cache
+      jekyll-seo-tag (>= 2.0)
+      rake (>= 12.3.1)
+    kramdown (2.5.2)
+      rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.10.0)
+      logger
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (7.0.5)
+    rake (13.4.2)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.7.0)
+    safe_yaml (1.0.5)
+    sass-embedded (1.101.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.101.0-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
+  ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
+
+DEPENDENCIES
+  jekyll (~> 4.3)
+  jekyll-seo-tag (~> 2.8)
+  jekyll-sitemap (~> 1.4)
+  just-the-docs (~> 0.10)
+  tzinfo (>= 1, < 3)
+  tzinfo-data
+
+BUNDLED WITH
+   2.6.9

--- a/docs/site/README.md
+++ b/docs/site/README.md
@@ -1,0 +1,131 @@
+# IronAdmin Documentation Site
+
+This directory contains the source for the **public IronAdmin documentation site**, a
+navigable, searchable web experience built from the Markdown docs that already live in
+[`docs/`](../). It is intended to be published to **GitHub Pages** at
+`https://rubylab-app.github.io/iron_admin/` (or a custom domain).
+
+> **Status: proposal + scaffold.** This is a working skeleton with a few real pages
+> migrated to prove the pipeline. Most sections are stubs with clear TODOs. The tooling
+> choice and the GitHub Pages setup need maintainer approval before this ships. See
+> [Maintainer decisions required](#maintainer-decisions-required).
+
+---
+
+## Tooling choice: Jekyll + `just-the-docs`
+
+We recommend **[Jekyll](https://jekyllrb.com/)** with the
+**[`just-the-docs`](https://just-the-docs.com/)** theme, deployed to GitHub Pages via a
+GitHub Actions workflow.
+
+### Why this is the right default for IronAdmin
+
+| Criterion | Why Jekyll + just-the-docs wins |
+|-----------|---------------------------------|
+| **Ruby-friendly** | IronAdmin is a Ruby gem. Jekyll is Ruby. Contributors already have a Ruby toolchain and `bundle install` muscle memory. No Node.js, npm, or a second language runtime to maintain. |
+| **Native GitHub Pages** | Jekyll is the *only* static generator GitHub Pages builds natively, and even with a custom Actions build it is the best-supported path. Zero third-party hosting. |
+| **Low maintenance** | The docs are already Markdown with front-matter-free bodies. Migration is mostly adding a small YAML front matter block. No build config churn. |
+| **Built-in search** | `just-the-docs` ships a client-side search index out of the box (`search_enabled: true`) — no external service (Algolia, etc.) to provision or pay for. |
+| **Navigation** | Automatic sidebar nav from `nav_order` / `parent` front matter, breadcrumbs, and child-page grouping — matches the existing `docs/` folder hierarchy almost 1:1. |
+| **Cost** | Free. GitHub Pages hosting + Actions minutes for public repos are free. |
+| **Versioning** | See [Doc versioning](#doc-versioning) below. |
+
+### Alternatives considered
+
+- **MkDocs Material** — Excellent theme and search, but it is a **Python** toolchain.
+  That adds a second language runtime to a Ruby project and splits contributor tooling.
+  Rejected for that reason alone; the theme quality does not outweigh the ecosystem
+  mismatch.
+- **Docusaurus** — Powerful, great versioning, but it is a **React/Node.js** app. Heaviest
+  maintenance burden (npm dependency churn, build complexity) and the furthest from a
+  gem's natural toolchain. Overkill for a docs site of this size.
+- **Plain GitHub `docs/` rendering** — What we have today. No search, no navigation, no
+  landing page, not a "site". This is exactly what the roadmap item asks us to move beyond.
+
+**Recommendation: Jekyll + just-the-docs.** It is the lowest-friction, lowest-cost,
+most Ruby-native option that still delivers search, navigation, and a polished landing page.
+
+---
+
+## Local development
+
+```bash
+cd docs/site
+bundle install
+bundle exec jekyll serve --livereload
+# open http://127.0.0.1:4000/iron_admin/
+```
+
+Requires Ruby >= 3.2 (matches the gem's `.ruby-version`).
+
+## Structure
+
+```
+docs/site/
+├── _config.yml            # Jekyll + just-the-docs configuration
+├── Gemfile                # jekyll + just-the-docs (pinned)
+├── index.md               # Landing page
+├── getting-started/
+│   ├── index.md           # Section landing
+│   ├── installation.md    # ✅ migrated (real content)
+│   └── quick-start.md     # ✅ migrated (real content)
+├── guides/
+│   ├── index.md           # Section landing
+│   ├── resource-dsl.md    # ✅ migrated (real content)
+│   ├── dashboards.md      # stub — TODO
+│   ├── fields.md          # stub — TODO
+│   ├── theming.md         # stub — TODO
+│   └── components.md      # stub — TODO
+├── adapters.md            # stub — TODO
+├── authorization.md       # stub — TODO
+├── imports-exports.md     # stub — TODO
+├── tools.md               # stub — TODO
+├── reference.md           # stub — TODO
+├── upgrade-guide.md       # stub — TODO
+└── faq.md                 # stub — TODO
+```
+
+### Content source of truth
+
+Every stub page lists the exact source file under [`docs/`](../) whose content should be
+migrated into it. The migration is mechanical: copy the body, add front matter
+(`title`, `parent`, `nav_order`), and fix relative links to point at site URLs.
+
+Three pages are **already fully migrated** to validate the pipeline end to end:
+Installation, Quick Start, and the Resource DSL guide.
+
+## Doc versioning
+
+Two viable approaches, to decide before the first `1.0`:
+
+1. **Latest-only (recommended to start).** The site tracks `main`. Simple, matches most
+   gems. Older versions remain readable via the git tag on GitHub and RubyGems.
+2. **Multi-version.** `just-the-docs` supports a version dropdown via the
+   [multiple-docs-sets pattern](https://just-the-docs.com/) or by building each release
+   tag into a versioned subpath (`/iron_admin/v0.6/`). Adds Actions complexity; defer
+   until there are breaking-change versions users must pin docs to.
+
+## Deploy
+
+Deployment is a **proposed** GitHub Actions workflow at
+[`.github/workflows/docs.yml`](../../.github/workflows/docs.yml). It is intentionally
+**not wired to auto-deploy** — it runs on `workflow_dispatch` (manual) only, plus builds
+(without deploying) on PRs that touch `docs/`. See that file's header comment.
+
+**Before it can deploy, a maintainer must:**
+1. Enable GitHub Pages for the repo with **Source: GitHub Actions**.
+2. Review and, if desired, add `push` to `main` as a deploy trigger.
+3. Optionally configure a custom domain (`CNAME`).
+
+---
+
+## Maintainer decisions required
+
+- [ ] **Approve the tooling choice** (Jekyll + just-the-docs) vs. an alternative.
+- [ ] **Enable GitHub Pages** with Source = GitHub Actions.
+- [ ] **Approve/adjust the deploy workflow** triggers in `.github/workflows/docs.yml`
+      (currently manual-only to avoid surprise deploys).
+- [ ] **Decide the versioning strategy** (latest-only vs. multi-version).
+- [ ] **Decide the URL** (project page `rubylab-app.github.io/iron_admin` vs. custom domain);
+      update `url` / `baseurl` in `_config.yml` accordingly.
+- [ ] **Migrate the remaining stub pages** from `docs/` (tracked as TODOs in each stub).

--- a/docs/site/_config.yml
+++ b/docs/site/_config.yml
@@ -1,0 +1,69 @@
+# Jekyll configuration for the IronAdmin documentation site.
+# Theme: just-the-docs (https://just-the-docs.com/)
+#
+# NOTE: `url`/`baseurl` assume a GitHub Pages *project* site at
+#   https://rubylab-app.github.io/iron_admin/
+# If a custom domain is configured, set `baseurl: ""` and `url` to the domain.
+
+title: IronAdmin
+description: >-
+  Convention-over-configuration admin panel engine for Ruby on Rails.
+  Build beautiful admin interfaces with minimal code.
+
+url: "https://rubylab-app.github.io"
+baseurl: "/iron_admin"
+
+theme: just-the-docs
+
+# --- just-the-docs options ---------------------------------------------------
+
+# Client-side search index (no external service required).
+search_enabled: true
+search:
+  heading_level: 2
+  previews: 3
+  tokenizer_separator: /[\s/]+/
+
+# Sidebar / navigation
+nav_external_links:
+  - title: IronAdmin on GitHub
+    url: https://github.com/rubylab-app/iron_admin
+  - title: IronAdmin on RubyGems
+    url: https://rubygems.org/gems/iron_admin
+
+# "Edit this page on GitHub" links point back at the raw docs source.
+gh_edit_link: true
+gh_edit_link_text: "Edit this page on GitHub"
+gh_edit_repository: "https://github.com/rubylab-app/iron_admin"
+gh_edit_branch: "main"
+gh_edit_source: "docs/site"
+gh_edit_view_mode: "tree"
+
+# Footer
+footer_content: >-
+  IronAdmin is open source under the
+  <a href="https://github.com/rubylab-app/iron_admin/blob/main/MIT-LICENSE">MIT License</a>.
+
+color_scheme: dark
+
+# Code copy button
+enable_copy_code_button: true
+
+# --- Jekyll options ----------------------------------------------------------
+
+plugins:
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+markdown: kramdown
+kramdown:
+  syntax_highlighter_opts:
+    block:
+      line_numbers: false
+
+exclude:
+  - Gemfile
+  - Gemfile.lock
+  - README.md
+  - vendor
+  - .bundle

--- a/docs/site/adapters.md
+++ b/docs/site/adapters.md
@@ -1,0 +1,18 @@
+---
+title: Adapters
+nav_order: 4
+permalink: /adapters/
+---
+
+# Adapters
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** Migrate the content from
+> [`docs/guides/custom-adapters.md`](https://github.com/rubylab-app/iron_admin/blob/main/docs/guides/custom-adapters.md)
+> (~628 lines — the largest single guide). **TODO:** copy the body, add front matter,
+> fix links. Given its length, consider splitting into child pages: "Adapter overview",
+> "Built-in adapters (ActiveRecord / Mongoid)", and "Writing a custom adapter".
+
+IronAdmin uses a pluggable adapter layer so resources can be backed by ActiveRecord,
+Mongoid, or a fully custom data source.

--- a/docs/site/authorization.md
+++ b/docs/site/authorization.md
@@ -4,7 +4,7 @@ nav_order: 5
 permalink: /authorization/
 ---
 
-# Authentication &amp; Authorization
+# Authentication & Authorization
 {: .no_toc }
 
 {: .warning }

--- a/docs/site/authorization.md
+++ b/docs/site/authorization.md
@@ -1,0 +1,17 @@
+---
+title: Authorization
+nav_order: 5
+permalink: /authorization/
+---
+
+# Authentication &amp; Authorization
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** Migrate the content from
+> [`docs/guides/authentication.md`](https://github.com/rubylab-app/iron_admin/blob/main/docs/guides/authentication.md).
+> **TODO:** copy the body, add front matter, fix links. Cross-link the `policy do … end`
+> section of the [Resource DSL guide](guides/resource-dsl/#policies).
+
+Configure who can sign in (`config.authenticate` / `config.current_user`) and the per-resource
+`policy` DSL for fine-grained `allow` / `deny` rules.

--- a/docs/site/faq.md
+++ b/docs/site/faq.md
@@ -1,0 +1,17 @@
+---
+title: FAQ
+nav_order: 10
+permalink: /faq/
+---
+
+# Frequently Asked Questions
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** Migrate the content from
+> [`docs/FAQ.md`](https://github.com/rubylab-app/iron_admin/blob/main/docs/FAQ.md).
+> **TODO:** copy the body, add front matter, fix links.
+
+Quick answers to common questions. Also see
+[Troubleshooting](https://github.com/rubylab-app/iron_admin/blob/main/docs/guides/troubleshooting.md)
+(**TODO:** migrate as a page under Guides).

--- a/docs/site/getting-started/index.md
+++ b/docs/site/getting-started/index.md
@@ -1,0 +1,14 @@
+---
+title: Getting Started
+nav_order: 2
+has_children: true
+permalink: /getting-started/
+---
+
+# Getting Started
+
+Everything you need to add IronAdmin to a Rails application and stand up your first admin
+panel.
+
+- **[Installation](installation/)** — add the gems, run the generator, wire up Tailwind CSS.
+- **[Quick Start](quick-start/)** — a full admin panel in six steps.

--- a/docs/site/getting-started/installation.md
+++ b/docs/site/getting-started/installation.md
@@ -1,0 +1,217 @@
+---
+title: Installation
+parent: Getting Started
+nav_order: 1
+permalink: /getting-started/installation/
+---
+
+# Installation
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+## Requirements
+
+- Ruby >= 3.2
+- Rails >= 7.1
+- [tailwindcss-rails](https://github.com/rails/tailwindcss-rails) >= 4.0
+
+## Step 1: Add the Gems
+
+Add IronAdmin and `tailwindcss-rails` to your `Gemfile`:
+
+```ruby
+gem "iron_admin"
+gem "tailwindcss-rails"
+```
+
+Then run:
+
+```bash
+bundle install
+```
+
+## Step 2: Run the Install Generator
+
+```bash
+rails generate iron_admin:install
+```
+
+This creates:
+
+| File | Purpose |
+|------|---------|
+| `config/initializers/iron_admin.rb` | Main configuration (title, auth, theme) |
+| `app/iron_admin/resources/` | Directory for resource definitions |
+| `app/iron_admin/dashboards/` | Directory for dashboard definitions |
+| `app/iron_admin/dashboards/admin_dashboard.rb` | Default dashboard class |
+
+It also:
+- Mounts the engine at `/admin` in `config/routes.rb`
+- Adds the IronAdmin CSS import to `app/assets/tailwind/application.css`
+
+## Step 3: Mount the Engine (if not auto-mounted)
+
+In `config/routes.rb`:
+
+```ruby
+Rails.application.routes.draw do
+  mount IronAdmin::Engine => "/admin"
+end
+```
+
+## Step 4: Configure Authentication
+
+Edit `config/initializers/iron_admin.rb`:
+
+```ruby
+IronAdmin.configure do |config|
+  config.title = "My App Admin"
+
+  config.authenticate do |controller|
+    unless controller.session[:user_id]
+      controller.redirect_to "/login"
+    end
+  end
+
+  config.current_user do |controller|
+    User.find_by(id: controller.session[:user_id])
+  end
+end
+```
+
+## Step 5: Create Your First Resource
+
+```bash
+rails generate iron_admin:resource User
+```
+
+This creates `app/iron_admin/resources/user_resource.rb`. IronAdmin automatically infers
+fields from your model's database schema.
+
+## Step 6: Build CSS and Start the Server
+
+```bash
+rails tailwindcss:build
+bin/rails server
+```
+
+Visit `/admin` and your admin panel is ready.
+
+For development with live CSS recompilation, use `bin/dev` (which runs
+`tailwindcss:watch` alongside the Rails server via foreman).
+
+{: .note }
+> There is a [known issue](https://github.com/rails/tailwindcss-rails/issues/602) in
+> `tailwindcss-rails` v4 where `bin/dev` exits immediately after starting. If this happens,
+> edit `Procfile.dev` and change the CSS line to
+> `css: bin/rails tailwindcss:watch[always]`.
+
+## Tailwind CSS Setup
+
+IronAdmin uses Tailwind CSS v4 for all styling via the `tailwindcss-rails` gem.
+Understanding how the CSS pipeline works will help you troubleshoot any styling issues.
+
+### How it works
+
+1. IronAdmin ships with `@source` directives at `app/assets/tailwind/iron_admin/engine.css`
+   inside the gem. These tell the Tailwind compiler where to scan for CSS utility classes
+   used by the engine's views, components, and helpers.
+
+2. When `tailwindcss:build` runs, it first executes `tailwindcss:engines`. This task
+   detects IronAdmin's engine CSS and creates a bridge file at
+   `app/assets/builds/tailwind/iron_admin.css` containing an `@import` that points
+   to the engine's CSS.
+
+3. Your `app/assets/tailwind/application.css` must import this bridge file:
+
+   ```css
+   @import "tailwindcss";
+   @import "../builds/tailwind/iron_admin";
+   ```
+
+4. The Tailwind compiler processes `application.css`, follows the imports, scans all
+   the engine's source files via the `@source` directives, and generates the final
+   `app/assets/builds/tailwind.css` with all necessary utility classes.
+
+5. The engine's layout references `stylesheet_link_tag "tailwind"`, which serves
+   this compiled CSS file.
+
+### Manual setup (without the generator)
+
+If you didn't use the install generator, or the import line is missing:
+
+1. Verify `tailwindcss-rails` is in your Gemfile and installed
+2. Add the import to `app/assets/tailwind/application.css`:
+
+   ```css
+   @import "tailwindcss";
+   @import "../builds/tailwind/iron_admin";
+   ```
+
+3. Build the CSS:
+
+   ```bash
+   rails tailwindcss:build
+   ```
+
+4. Verify the build output:
+
+   ```bash
+   ls -la app/assets/builds/tailwind.css
+   # Should be ~30KB+ (not ~6KB which indicates no utility classes)
+   ```
+
+### Troubleshooting
+
+**Styles not loading (unstyled admin panel)**
+
+This almost always means the Tailwind compiler didn't scan IronAdmin's source files.
+Check:
+
+1. The `@import "../builds/tailwind/iron_admin"` line exists in
+   `app/assets/tailwind/application.css`
+2. The bridge file exists at `app/assets/builds/tailwind/iron_admin.css`
+   (run `rails tailwindcss:build` to regenerate it)
+3. The compiled CSS at `app/assets/builds/tailwind.css` is large enough
+   (~30KB+, not ~6KB)
+
+**Bridge file not generated**
+
+If `app/assets/builds/tailwind/iron_admin.css` doesn't exist after running
+`rails tailwindcss:build`:
+
+- Ensure `tailwindcss-rails` >= 4.0 is installed (`bundle info tailwindcss-rails`)
+- Ensure `iron_admin` is properly loaded (check `bundle info iron_admin`)
+- Try running `rails tailwindcss:engines` directly
+
+**Styles disappear after bundle update**
+
+The bridge file uses an absolute path to the gem's CSS. After updating the gem
+(which changes the gem path), run `rails tailwindcss:build` to regenerate it.
+
+## Dependencies
+
+IronAdmin depends on the following gems (installed automatically):
+
+| Gem | Version | Purpose |
+|-----|---------|---------|
+| `rails` | >= 7.1 | Framework |
+| `view_component` | >= 3.0 | UI components |
+| `turbo-rails` | >= 2.0 | Hotwire Turbo |
+| `stimulus-rails` | >= 1.3 | Hotwire Stimulus |
+| `pagy` | >= 6.0 | Pagination |
+| `haml-rails` | >= 2.0 | Template engine |
+| `heroicon` | >= 1.0 | SVG icons |
+
+**Peer dependency** (must be added to your Gemfile manually):
+
+| Gem | Version | Purpose |
+|-----|---------|---------|
+| `tailwindcss-rails` | >= 4.0 | Tailwind CSS compilation |

--- a/docs/site/getting-started/quick-start.md
+++ b/docs/site/getting-started/quick-start.md
@@ -1,0 +1,114 @@
+---
+title: Quick Start
+parent: Getting Started
+nav_order: 2
+permalink: /getting-started/quick-start/
+---
+
+# Quick Start
+{: .no_toc }
+
+Get a full admin panel running in 6 steps.
+
+---
+
+## Prerequisites
+
+IronAdmin uses [Tailwind CSS](https://tailwindcss.com/) for all styling and requires
+`tailwindcss-rails` >= 4.0. Ensure your application has a supported version installed:
+
+```bash
+bundle add tailwindcss-rails --version ">= 4.0"
+rails tailwindcss:install
+```
+
+## 1. Install
+
+```bash
+bundle add iron_admin
+rails generate iron_admin:install
+```
+
+## 2. Configure Authentication
+
+```ruby
+# config/initializers/iron_admin.rb
+IronAdmin.configure do |config|
+  config.title = "My App Admin"
+
+  config.authenticate do |controller|
+    user = User.find_by(id: controller.session[:user_id])
+    controller.redirect_to "/login" unless user&.admin?
+  end
+
+  config.current_user do |controller|
+    User.find_by(id: controller.session[:user_id])
+  end
+end
+```
+
+## 3. Generate Resources
+
+```bash
+rails generate iron_admin:resource User
+rails generate iron_admin:resource Product
+rails generate iron_admin:resource Order
+```
+
+IronAdmin infers all fields from your database schema automatically. No configuration
+needed for basic CRUD.
+
+## 4. Customize a Resource
+
+```ruby
+# app/iron_admin/resources/user_resource.rb
+class UserResource < IronAdmin::Resource
+  field :role, type: :badge, colors: { admin: :purple, user: :blue }
+  field :email, type: :text
+
+  searchable :name, :email
+  filter :role, type: :select, choices: User.roles.keys
+  filter :created_at, type: :date_range
+
+  scope :admins, -> { where(role: :admin) }
+  scope :recent, -> { where("created_at > ?", 7.days.ago) }
+
+  index_fields :id, :name, :email, :role, :created_at
+  form_fields :name, :email, :role
+
+  menu priority: 1, icon: "users", group: "People"
+
+  action :lock, icon: "lock-closed", confirm: true do |record|
+    record.update!(locked_at: Time.current)
+  end
+end
+```
+
+See the [Resource DSL guide](../guides/resource-dsl/) for the full set of options.
+
+## 5. Create a Dashboard
+
+```ruby
+# app/iron_admin/dashboards/admin_dashboard.rb
+class AdminDashboard < IronAdmin::Dashboard
+  metric :total_users, format: :number do
+    User.count
+  end
+
+  metric :monthly_revenue, format: :currency do
+    Payment.where("created_at > ?", 30.days.ago).sum(:amount)
+  end
+
+  recent :users, limit: 5, scope: -> { order(created_at: :desc) }
+  recent :payments, limit: 5
+end
+```
+
+## 6. Build CSS and Start
+
+```bash
+rails tailwindcss:build
+bin/rails server
+```
+
+Visit `/admin` and your admin panel is ready.

--- a/docs/site/getting-started/quick-start.md
+++ b/docs/site/getting-started/quick-start.md
@@ -62,24 +62,28 @@ needed for basic CRUD.
 
 ```ruby
 # app/iron_admin/resources/user_resource.rb
-class UserResource < IronAdmin::Resource
-  field :role, type: :badge, colors: { admin: :purple, user: :blue }
-  field :email, type: :text
+module IronAdmin
+  module Resources
+    class UserResource < IronAdmin::Resource
+      field :role, type: :badge, colors: { admin: :purple, user: :blue }
+      field :email, type: :text
 
-  searchable :name, :email
-  filter :role, type: :select, choices: User.roles.keys
-  filter :created_at, type: :date_range
+      searchable :name, :email
+      filter :role, type: :select, options: User.roles.keys
+      filter :created_at, type: :date_range
 
-  scope :admins, -> { where(role: :admin) }
-  scope :recent, -> { where("created_at > ?", 7.days.ago) }
+      scope :admins, -> { where(role: :admin) }
+      scope :recent, -> { where("created_at > ?", 7.days.ago) }
 
-  index_fields :id, :name, :email, :role, :created_at
-  form_fields :name, :email, :role
+      index_fields :id, :name, :email, :role, :created_at
+      form_fields :name, :email, :role
 
-  menu priority: 1, icon: "users", group: "People"
+      menu priority: 1, icon: "users", group: "People"
 
-  action :lock, icon: "lock-closed", confirm: true do |record|
-    record.update!(locked_at: Time.current)
+      action :lock, icon: "lock-closed", confirm: true do |record|
+        record.update!(locked_at: Time.current)
+      end
+    end
   end
 end
 ```

--- a/docs/site/getting-started/quick-start.md
+++ b/docs/site/getting-started/quick-start.md
@@ -94,17 +94,21 @@ See the [Resource DSL guide](../guides/resource-dsl/) for the full set of option
 
 ```ruby
 # app/iron_admin/dashboards/admin_dashboard.rb
-class AdminDashboard < IronAdmin::Dashboard
-  metric :total_users, format: :number do
-    User.count
-  end
+module IronAdmin
+  module Dashboards
+    class AdminDashboard < IronAdmin::Dashboard
+      metric :total_users, format: :number do
+        User.count
+      end
 
-  metric :monthly_revenue, format: :currency do
-    Payment.where("created_at > ?", 30.days.ago).sum(:amount)
-  end
+      metric :monthly_revenue, format: :currency do
+        Payment.where("created_at > ?", 30.days.ago).sum(:amount)
+      end
 
-  recent :users, limit: 5, scope: -> { order(created_at: :desc) }
-  recent :payments, limit: 5
+      recent :users, limit: 5, scope: -> { order(created_at: :desc) }
+      recent :payments, limit: 5
+    end
+  end
 end
 ```
 

--- a/docs/site/guides/components.md
+++ b/docs/site/guides/components.md
@@ -1,0 +1,20 @@
+---
+title: Components
+parent: Guides
+nav_order: 5
+permalink: /guides/components/
+---
+
+# Components
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** Migrate the content from
+> [`docs/guides/components.md`](https://github.com/rubylab-app/iron_admin/blob/main/docs/guides/components.md)
+> and the component library under
+> [`docs/components/`](https://github.com/rubylab-app/iron_admin/tree/main/docs/components).
+> **TODO:** copy the body, add front matter, fix links. Consider splitting the
+> component library (UI / Form / Filter / Resource / Dashboard components) into
+> child pages under this section.
+
+Override and extend the built-in ViewComponents.

--- a/docs/site/guides/dashboards.md
+++ b/docs/site/guides/dashboards.md
@@ -1,0 +1,23 @@
+---
+title: Dashboards
+parent: Guides
+nav_order: 2
+permalink: /guides/dashboards/
+---
+
+# Dashboards
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** Migrate the content from
+> [`docs/guides/dashboard.md`](https://github.com/rubylab-app/iron_admin/blob/main/docs/guides/dashboard.md).
+> **TODO:** copy the body, add front matter, and fix relative links to site URLs.
+
+Configure metrics, charts, and recent-record widgets for the `/admin` dashboard.
+
+```ruby
+class AdminDashboard < IronAdmin::Dashboard
+  metric(:total_users, format: :number) { User.count }
+  recent :users, limit: 5
+end
+```

--- a/docs/site/guides/dashboards.md
+++ b/docs/site/guides/dashboards.md
@@ -16,8 +16,12 @@ permalink: /guides/dashboards/
 Configure metrics, charts, and recent-record widgets for the `/admin` dashboard.
 
 ```ruby
-class AdminDashboard < IronAdmin::Dashboard
-  metric(:total_users, format: :number) { User.count }
-  recent :users, limit: 5
+module IronAdmin
+  module Dashboards
+    class AdminDashboard < IronAdmin::Dashboard
+      metric(:total_users, format: :number) { User.count }
+      recent :users, limit: 5
+    end
+  end
 end
 ```

--- a/docs/site/guides/fields.md
+++ b/docs/site/guides/fields.md
@@ -1,0 +1,17 @@
+---
+title: Fields
+parent: Guides
+nav_order: 3
+permalink: /guides/fields/
+---
+
+# Fields
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** Migrate the content from
+> [`docs/guides/fields.md`](https://github.com/rubylab-app/iron_admin/blob/main/docs/guides/fields.md).
+> **TODO:** copy the body, add front matter, and fix relative links to site URLs.
+
+Field types, schema inference, and per-view customization. See the
+[Resource DSL guide](resource-dsl/#fields) for the field DSL basics.

--- a/docs/site/guides/index.md
+++ b/docs/site/guides/index.md
@@ -1,0 +1,17 @@
+---
+title: Guides
+nav_order: 3
+has_children: true
+permalink: /guides/
+---
+
+# Guides
+
+In-depth guides for building with IronAdmin.
+
+- **[Resource DSL](resource-dsl/)** — the full DSL for fields, filters, scopes, actions,
+  associations, and more.
+- **[Dashboards](dashboards/)** — metrics, charts, and recent-record widgets. _(stub)_
+- **[Fields](fields/)** — field types, inference, and customization. _(stub)_
+- **[Theming](theming/)** — customize every visual aspect. _(stub)_
+- **[Components](components/)** — override and extend UI components. _(stub)_

--- a/docs/site/guides/resource-dsl.md
+++ b/docs/site/guides/resource-dsl.md
@@ -28,9 +28,18 @@ rails generate iron_admin:resource User
 Creates `app/iron_admin/resources/user_resource.rb`:
 
 ```ruby
-class UserResource < IronAdmin::Resource
+module IronAdmin
+  module Resources
+    class UserResource < IronAdmin::Resource
+    end
+  end
 end
 ```
+
+Resources live under the `IronAdmin::Resources` namespace — that is what the
+generator creates and what the engine's autoloader expects. **The examples
+below show only the class body for brevity; wrap each one in the same
+`module IronAdmin; module Resources; … end; end` nesting shown above.**
 
 By convention, `UserResource` maps to the `User` model. To override:
 
@@ -112,7 +121,7 @@ to see.
 
 ```ruby
 class UserResource < IronAdmin::Resource
-  filter :role, type: :select, choices: User.roles.keys
+  filter :role, type: :select, options: User.roles.keys
   filter :created_at, type: :date_range
   filter :email_verified, type: :boolean
 end
@@ -251,7 +260,7 @@ ActionField options:
 | `type` | Symbol | Input type (see list above) |
 | `required` | Boolean | Whether the field must be filled |
 | `default` | Object | Default value for the input |
-| `choices` | Array | Options for `:select` type |
+| `options` | Array | Options for `:select` type |
 
 Action forms work with both record actions and bulk actions.
 
@@ -276,7 +285,7 @@ Bulk actions validate that all selected records are accessible to the current us
 
 ```ruby
 class AuditLogResource < IronAdmin::Resource
-  deny_actions :create, :update, :delete
+  deny_actions :create, :update, :destroy
 end
 ```
 
@@ -335,15 +344,15 @@ end
 
 ### Large Association Handling
 
-For `belongs_to` fields with many options (>100 records), IronAdmin automatically uses an
-autocomplete component instead of a dropdown:
+For `belongs_to` fields with many options, opt in to an autocomplete component
+(instead of loading every record into a dropdown) with `autocomplete: true`:
 
 ```ruby
 class OrderResource < IronAdmin::Resource
   field :customer_id, type: :belongs_to,
         association: :customer,
-        display: :name
-  # Autocomplete is used automatically if Customer has >100 records
+        display: :name,
+        autocomplete: true
 end
 ```
 

--- a/docs/site/guides/resource-dsl.md
+++ b/docs/site/guides/resource-dsl.md
@@ -1,0 +1,427 @@
+---
+title: Resource DSL
+parent: Guides
+nav_order: 1
+permalink: /guides/resource-dsl/
+---
+
+# Resource DSL
+{: .no_toc }
+
+## Table of contents
+{: .no_toc .text-delta }
+
+1. TOC
+{:toc}
+
+---
+
+Resources are the core building block of IronAdmin. Each resource maps to a model
+(ActiveRecord or Mongoid) and defines how it appears in the admin panel.
+
+## Generating a Resource
+
+```bash
+rails generate iron_admin:resource User
+```
+
+Creates `app/iron_admin/resources/user_resource.rb`:
+
+```ruby
+class UserResource < IronAdmin::Resource
+end
+```
+
+By convention, `UserResource` maps to the `User` model. To override:
+
+```ruby
+class UserResource < IronAdmin::Resource
+  self.model_class_override = Account
+end
+```
+
+## Fields
+
+Fields are automatically inferred from the database schema. Override specific fields:
+
+```ruby
+class UserResource < IronAdmin::Resource
+  field :status, type: :badge, colors: { active: :green, suspended: :red }
+  field :bio, type: :textarea
+  field :role, type: :select, choices: %w[user admin]
+  field :secret, visible: false
+  field :email, readonly: true
+  field :admin_notes, visible: ->(user) { user.admin? }
+  field :salary, readonly: ->(user) { !user.admin? }
+end
+```
+
+### Field Options
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `type` | Symbol | Field type (`:text`, `:textarea`, `:number`, `:boolean`, `:date`, `:datetime`, `:select`, `:badge`, `:json`, `:belongs_to`) |
+| `visible` | Boolean/Proc | Show or hide the field. Proc receives current user |
+| `readonly` | Boolean/Proc | Make field read-only. Proc receives current user |
+| `colors` | Hash | Badge color mapping (for `:badge` type) |
+| `choices` | Array | Options for `:select` type |
+
+### Controlling Field Visibility per View
+
+```ruby
+class UserResource < IronAdmin::Resource
+  index_fields :id, :name, :email, :role, :created_at
+  form_fields :name, :email, :role
+  export_fields :id, :name, :email, :role
+end
+```
+
+## Search
+
+```ruby
+class UserResource < IronAdmin::Resource
+  searchable :name, :email
+end
+```
+
+If not specified, all `string` and `text` columns are searchable (excluding `*_digest`
+columns).
+
+### Advanced Search Syntax
+
+IronAdmin supports field-specific search queries:
+
+```
+email:john@example.com     # Search email field only
+name:John                  # Search name field only
+role:admin                 # Search role field only
+```
+
+Date range search:
+
+```
+created_at:2025-01-01..2025-12-31    # Records created in 2025
+created_at:2025-06-01..              # Records from June 2025 onwards
+created_at:..2025-06-30              # Records before July 2025
+```
+
+Search respects field visibility - users cannot search fields they don't have permission
+to see.
+
+## Filters
+
+```ruby
+class UserResource < IronAdmin::Resource
+  filter :role, type: :select, choices: User.roles.keys
+  filter :created_at, type: :date_range
+  filter :email_verified, type: :boolean
+end
+```
+
+Remove auto-inferred filters:
+
+```ruby
+remove_filter :some_column
+```
+
+### Filter Types
+
+| Type | Description |
+|------|-------------|
+| `:select` | Dropdown with choices |
+| `:date_range` | Date range picker |
+| `:boolean` | True/false toggle |
+| `:string` | Text input with operator dropdown (contains, equals, starts_with, ends_with) |
+| `:number` | Number input with operator dropdown (equals, greater_than, less_than, between) |
+
+### String and Number Filters
+
+String and number filters provide an operator dropdown alongside the input:
+
+```ruby
+class ProductResource < IronAdmin::Resource
+  filter :name, type: :string       # contains, equals, starts_with, ends_with
+  filter :price, type: :number      # equals, greater_than, less_than, between
+end
+```
+
+**Auto-inference:** String and text columns automatically infer as `:string` filters.
+Integer, float, and decimal columns automatically infer as `:number` filters. You only
+need explicit declarations to override defaults or add filters for columns that aren't
+auto-detected.
+
+### Auto-Generated Enum Filters
+
+If your model uses Rails enums, IronAdmin automatically creates select filters:
+
+```ruby
+# app/models/order.rb
+class Order < ApplicationRecord
+  enum :status, { pending: 0, processing: 1, shipped: 2, delivered: 3 }
+end
+
+# No filter definition needed - auto-generated from enum
+class OrderResource < IronAdmin::Resource
+end
+```
+
+The filter will display with humanized labels (Pending, Processing, Shipped, Delivered).
+
+## Scopes
+
+Scopes are predefined query filters shown as tabs:
+
+```ruby
+class UserResource < IronAdmin::Resource
+  scope :all, -> { all }, default: true
+  scope :admins, -> { where(role: :admin) }
+  scope :recent, -> { where("created_at > ?", 7.days.ago) }
+  scope :locked, -> { where.not(locked_at: nil) }
+end
+```
+
+## Soft Delete Support
+
+IronAdmin auto-detects models with a `deleted_at` column and provides:
+
+- **Auto-registered scopes**: `with_deleted` and `only_deleted`
+- **Auto-registered restore action**: Restores soft-deleted records
+
+```ruby
+# If your model has deleted_at column, these are auto-registered:
+class PostResource < IronAdmin::Resource
+  # Auto: scope :with_deleted, -> { unscoped }
+  # Auto: scope :only_deleted, -> { only_deleted }
+  # Auto: action :restore { |r| r.update!(deleted_at: nil) }
+end
+```
+
+Works with gems like `paranoia`, `discard`, or custom soft delete implementations.
+
+## Actions
+
+### Record Actions
+
+```ruby
+class UserResource < IronAdmin::Resource
+  action :lock, icon: "lock-closed", confirm: true do |record|
+    record.update!(locked_at: Time.current)
+  end
+
+  action :send_reset, icon: "envelope" do |record|
+    AuthMailer.password_reset(record).deliver_later
+  end
+end
+```
+
+Actions are wrapped in database transactions. Return `false` to rollback:
+
+```ruby
+action :process do |record|
+  return false unless record.can_process?
+  record.process!
+end
+```
+
+### Action Forms
+
+Actions can collect user input before executing by specifying `form_fields:`. The form is
+displayed in a modal when the action is triggered.
+
+```ruby
+class OrderResource < IronAdmin::Resource
+  action :reject,
+    form_fields: [
+      action_field(:reason, type: :textarea, required: true),
+      action_field(:notify_customer, type: :boolean, default: true)
+    ] do |record, params|
+      record.reject!(reason: params[:reason])
+      Mailer.rejection(record).deliver_later if params[:notify_customer]
+    end
+end
+```
+
+**ActionField types:** `text`, `textarea`, `number`, `boolean`, `date`, `datetime`,
+`select`.
+
+ActionField options:
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `type` | Symbol | Input type (see list above) |
+| `required` | Boolean | Whether the field must be filled |
+| `default` | Object | Default value for the input |
+| `choices` | Array | Options for `:select` type |
+
+Action forms work with both record actions and bulk actions.
+
+### Bulk Actions
+
+```ruby
+class UserResource < IronAdmin::Resource
+  bulk_action :delete_many do |records|
+    records.each(&:destroy!)
+  end
+
+  bulk_action :lock_all do |records|
+    records.update_all(locked_at: Time.current)
+  end
+end
+```
+
+Bulk actions validate that all selected records are accessible to the current user
+(respecting tenant scope).
+
+## CRUD Restrictions
+
+```ruby
+class AuditLogResource < IronAdmin::Resource
+  deny_actions :create, :update, :delete
+end
+```
+
+## Associations
+
+```ruby
+class UserResource < IronAdmin::Resource
+  has_many :licenses, display: :license_key
+  has_many :subscriptions
+  belongs_to :organization
+  has_one :profile
+end
+```
+
+### Polymorphic Associations
+
+IronAdmin auto-detects polymorphic `belongs_to` associations. You can also declare them
+explicitly with the `types` option to specify which models are allowed:
+
+```ruby
+class CommentResource < IronAdmin::Resource
+  belongs_to :commentable, polymorphic: true, types: [Article, Photo, Video]
+end
+```
+
+On forms, a type selector dropdown and an ID selector are rendered. On show and index
+pages, the associated record is displayed as a linked reference (e.g., "Article #42").
+
+The `FieldInferrer` automatically detects polymorphic associations when a model has
+`*_type` and `*_id` column pairs and creates a `:polymorphic_belongs_to` field type.
+
+### HABTM Associations
+
+`has_and_belongs_to_many` associations are supported with a checkbox UI on forms and badge
+display on show pages:
+
+```ruby
+class ArticleResource < IronAdmin::Resource
+  has_and_belongs_to_many :tags
+end
+```
+
+### Association Preloading
+
+IronAdmin automatically preloads associations to prevent N+1 queries:
+
+- `belongs_to` associations shown in index are preloaded
+- Related records displayed on show pages are preloaded
+- Custom preloads can be added:
+
+```ruby
+class OrderResource < IronAdmin::Resource
+  preload :customer, :line_items, :shipping_address
+end
+```
+
+### Large Association Handling
+
+For `belongs_to` fields with many options (>100 records), IronAdmin automatically uses an
+autocomplete component instead of a dropdown:
+
+```ruby
+class OrderResource < IronAdmin::Resource
+  field :customer_id, type: :belongs_to,
+        association: :customer,
+        display: :name
+  # Autocomplete is used automatically if Customer has >100 records
+end
+```
+
+## Nested Forms
+
+For `has_many` and `has_one` associations, you can enable inline nested editing directly on
+the parent form. The model must declare `accepts_nested_attributes_for` for the association.
+
+```ruby
+class OrderResource < IronAdmin::Resource
+  # has_many with nested editing
+  has_many :line_items, nested: true, allow_destroy: true
+
+  # Explicit field selection
+  has_many :addresses, nested: true, fields: [:street, :city, :zip]
+
+  # With drag-and-drop ordering (via Stimulus)
+  has_many :sections, nested: true, position_field: :position
+
+  # has_one nested
+  has_one :profile, nested: true
+end
+```
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `nested` | `false` | Enable inline nested form for the association |
+| `allow_destroy` | `true` | Allow removing child records from the form |
+| `fields` | auto-inferred | Explicit list of child fields to display (excludes `id`, timestamps, and FK by default) |
+| `position_field` | `nil` | Column name for drag-and-drop reordering |
+
+Nested forms use the existing `create` and `update` endpoints -- no additional routes are
+required. Child attributes are submitted as standard Rails nested attributes
+(`*_attributes` params).
+
+## Menu Configuration
+
+```ruby
+class UserResource < IronAdmin::Resource
+  menu priority: 1, icon: "users", group: "People"
+end
+```
+
+## Exports
+
+```ruby
+class UserResource < IronAdmin::Resource
+  exports :csv, :json
+  export_fields :id, :name, :email, :role, :created_at
+end
+```
+
+Exports respect:
+- Tenant scoping (if configured)
+- Field visibility (users only see fields they have permission to view)
+- Current filters and search query
+
+See [Imports & Exports](../imports-exports/) for more.
+
+## Policies
+
+```ruby
+class UserResource < IronAdmin::Resource
+  policy do
+    allow :read, :update
+    deny :destroy, if: ->(user) { !user.superadmin? }
+  end
+end
+```
+
+See [Authorization](../authorization/) for details.
+
+## Component Overrides
+
+```ruby
+class UserResource < IronAdmin::Resource
+  component :table, CustomUserTableComponent
+end
+```

--- a/docs/site/guides/theming.md
+++ b/docs/site/guides/theming.md
@@ -1,0 +1,17 @@
+---
+title: Theming
+parent: Guides
+nav_order: 4
+permalink: /guides/theming/
+---
+
+# Theming
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** Migrate the content from
+> [`docs/guides/theming.md`](https://github.com/rubylab-app/iron_admin/blob/main/docs/guides/theming.md).
+> **TODO:** copy the body, add front matter, fix links. Also cross-link the
+> [Theme Properties reference](../reference/#theme-properties).
+
+Every UI element is a configurable Tailwind CSS class via `config.theme`.

--- a/docs/site/imports-exports.md
+++ b/docs/site/imports-exports.md
@@ -1,0 +1,17 @@
+---
+title: Imports &amp; Exports
+nav_order: 6
+permalink: /imports-exports/
+---
+
+# Imports &amp; Exports
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** Migrate the content from
+> [`docs/guides/export.md`](https://github.com/rubylab-app/iron_admin/blob/main/docs/guides/export.md).
+> **TODO:** copy the body, add front matter, fix links. If an import feature exists or is
+> planned, document it here alongside exports.
+
+CSV and JSON export out of the box, respecting tenant scope, field visibility, and the
+current filters/search.

--- a/docs/site/imports-exports.md
+++ b/docs/site/imports-exports.md
@@ -1,10 +1,10 @@
 ---
-title: Imports &amp; Exports
+title: Imports & Exports
 nav_order: 6
 permalink: /imports-exports/
 ---
 
-# Imports &amp; Exports
+# Imports & Exports
 {: .no_toc }
 
 {: .warning }

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,0 +1,63 @@
+---
+title: Home
+layout: home
+nav_order: 1
+description: "IronAdmin — convention-over-configuration admin panel engine for Ruby on Rails."
+permalink: /
+---
+
+# IronAdmin
+{: .fs-9 }
+
+Convention-over-configuration admin panel engine for Ruby on Rails. Build beautiful admin
+interfaces with minimal code.
+{: .fs-6 .fw-300 }
+
+[Get started now](getting-started/){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[View on GitHub](https://github.com/rubylab-app/iron_admin){: .btn .fs-5 .mb-4 .mb-md-0 }
+
+---
+
+## What is IronAdmin?
+
+IronAdmin is a mountable Rails Engine that auto-generates CRUD admin interfaces directly
+from your ActiveRecord (or Mongoid) models. Mount it at `/admin`, point it at your models,
+and get a polished, searchable, themeable admin panel with almost no boilerplate.
+
+```ruby
+# Gemfile
+gem "iron_admin"
+gem "tailwindcss-rails"
+```
+
+```bash
+bundle install
+rails generate iron_admin:install
+```
+
+## Features
+
+- **Zero-configuration CRUD** — forms and tables inferred from your database schema.
+- **Resource DSL** — customize fields, filters, scopes, and actions in clean Ruby.
+- **Dashboard builder** — metrics, charts, and recent-record widgets.
+- **Theme system** — every UI element is a configurable Tailwind class.
+- **Authorization** — a built-in policy DSL for fine-grained access control.
+- **Adapters** — pluggable data-layer support (ActiveRecord, Mongoid, and custom).
+- **Search & export** — global search and CSV/JSON export out of the box.
+
+## Requirements
+
+- Ruby >= 3.2
+- Rails >= 7.1
+- [tailwindcss-rails](https://github.com/rails/tailwindcss-rails) >= 4.0
+
+## Where to next?
+
+| I want to… | Go to |
+|------------|-------|
+| Install IronAdmin | [Installation](getting-started/installation/) |
+| Build my first admin panel | [Quick Start](getting-started/quick-start/) |
+| Learn the resource DSL | [Resource DSL](guides/resource-dsl/) |
+| Secure the admin | [Authorization](authorization/) |
+| Support a custom data layer | [Adapters](adapters/) |
+| Upgrade a major version | [Upgrade Guide](upgrade-guide/) |

--- a/docs/site/reference.md
+++ b/docs/site/reference.md
@@ -1,0 +1,21 @@
+---
+title: Reference
+nav_order: 8
+permalink: /reference/
+---
+
+# Reference
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** Migrate the reference docs from
+> [`docs/reference/`](https://github.com/rubylab-app/iron_admin/tree/main/docs/reference):
+> `configuration.md`, `routes.md`, and `theme-properties.md`.
+> **TODO:** convert each into a child page of this section (`has_children: true`),
+> add front matter, and fix links.
+
+Complete reference material:
+
+- **Configuration** — every `IronAdmin.configure` option.
+- **Routes** — the routes the engine mounts.
+- **Theme Properties** — the full list of themeable Tailwind class properties.

--- a/docs/site/tools.md
+++ b/docs/site/tools.md
@@ -1,0 +1,17 @@
+---
+title: Tools
+nav_order: 7
+permalink: /tools/
+---
+
+# Tools
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** No standalone tools guide exists yet under `docs/`.
+> **TODO:** author this page from the v0.6.0 "Tool System Enhancement" feature notes in
+> [`CHANGELOG.md`](https://github.com/rubylab-app/iron_admin/blob/main/CHANGELOG.md)
+> and the relevant source under `lib/iron_admin/`. Document how tools are defined,
+> registered, and surfaced in the admin UI.
+
+The tool system lets you register custom admin utilities beyond standard CRUD.

--- a/docs/site/upgrade-guide.md
+++ b/docs/site/upgrade-guide.md
@@ -1,0 +1,17 @@
+---
+title: Upgrade Guide
+nav_order: 9
+permalink: /upgrade-guide/
+---
+
+# Upgrade Guide
+{: .no_toc }
+
+{: .warning }
+> **This page is a stub.** Migrate the content from the repo-root
+> [`UPGRADING.md`](https://github.com/rubylab-app/iron_admin/blob/main/UPGRADING.md).
+> **TODO:** copy the body, add front matter, fix links. Also link the
+> [`CHANGELOG.md`](https://github.com/rubylab-app/iron_admin/blob/main/CHANGELOG.md)
+> for the full release history.
+
+Version-by-version upgrade notes and breaking changes.


### PR DESCRIPTION
Closes #111.

Scaffolds a navigable, searchable public documentation site under `docs/site/`, built with Jekyll + `just-the-docs` and intended for GitHub Pages.

## What's here
- **Tooling + rationale** in `docs/site/README.md` (Jekyll + just-the-docs vs MkDocs Material / Docusaurus).
- **Full section structure**: Getting Started, Guides, Adapters, Authorization, Imports & Exports, Tools, Reference, Upgrade Guide, FAQ.
- **3 pages fully migrated** (Installation, Quick Start, Resource DSL); the rest are stubs with TODOs pointing at their source files.
- **Conservative deploy workflow** `.github/workflows/docs.yml`: builds on docs PRs, deploys **only** via manual `workflow_dispatch` — never auto-deploys on push.

## Content accuracy
The migrated pages were audited against the real DSL and corrected: resources/dashboards are namespaced under `IronAdmin::Resources` / `IronAdmin::Dashboards` (matching the generator + autoloader), select **filters** and action-form fields use `options:` (`choices:` is correct only for `:select` **fields**), `deny_actions` uses `:destroy`, and `belongs_to` autocomplete is documented as opt-in (`autocomplete: true`).

## Maintainer setup needed before it can publish
Enable GitHub Pages (Source = GitHub Actions), confirm the final URL / `baseurl`, and approve the deploy workflow. Nothing here deploys automatically.

## Verification
- `bundle exec jekyll build` succeeds (17 pages + search index; only upstream just-the-docs Sass deprecation warnings).
- No Ruby source touched, so RuboCop/RSpec are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)